### PR TITLE
remove export default

### DIFF
--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 /* eslint-enable no-var */
 
-export default {
+module.exports = {
     basic: {
         vertex: fs.readFileSync(path.join(__dirname, '/basic.vert.glsl'), 'utf8'),
         fragment: fs.readFileSync(path.join(__dirname, '/basic.frag.glsl'), 'utf8')


### PR DESCRIPTION
Мелькают сообшения, что `export default` удалён из спецификации: http://stackoverflow.com/questions/21117160/what-is-export-default-in-javascript . При обновлении babelify он начинает работать неправильно. Пока правильный вариант синтаксиса найти не удалось.