### PR TITLE
Change build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
   "presets": [
     "es2015"
+  ],
+  "plugins": [
+    "babel-plugin-add-module-exports"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ npm-debug.log
 coverage
 docs
 dist
+*.vert.js
+*.frag.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+npm-debug.log
+coverage
+docs
+examples
+src
+test
+.babelrc
+.eslintrc
+.travis.yml
+jsdoc.json
+buildShaders.js
+.npmignore

--- a/buildShaders.js
+++ b/buildShaders.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+getFilesByExtName(path.join(__dirname, 'src'), '.glsl')
+    .then(files => {
+        return Promise.all(files.map(file => {
+            const newFileSrc = file.replace('glsl', 'js');
+
+            return readFile(file)
+                .then(convertGLSL)
+                .then(writeFile(newFileSrc));
+        }));
+    })
+    .catch(error => console.error(error));
+
+function getFilesByExtName(src, extName) {
+    return getAllFiles(src)
+        .then(res => res.filter(src => {
+            return path.extname(src) === extName;
+        }));
+}
+
+function getAllFiles(src) {
+    return readDir(src)
+        .then(files => {
+            return Promise.all(files.map(file => {
+                const fileSrc = path.join(src, file);
+
+                return stat(fileSrc)
+                    .then(file => {
+                        if (file.isDirectory()) {
+                            return getAllFiles(fileSrc);
+                        }
+
+                        return fileSrc;
+                    });
+            }));
+        })
+        .then(result => result.reduce((array, el) => {
+            return array.concat(el);
+        }, []));
+}
+
+function readDir(src) {
+    return new Promise((resolve, reject) => {
+        fs.readdir(src, callback(resolve, reject));
+    });
+}
+
+function stat(src) {
+    return new Promise((resolve, reject) => {
+        fs.stat(src, callback(resolve, reject));
+    });
+}
+
+function readFile(src) {
+    return new Promise((resolve, reject) => {
+        fs.readFile(src, 'utf8', callback(resolve, reject));
+    });
+}
+
+function writeFile(src) {
+    return text => new Promise((resolve, reject) => {
+        fs.writeFile(src, text, 'utf8', callback(resolve, reject));
+    });
+}
+
+function callback(resolve, reject) {
+    return (error, data) => {
+        if (error) {
+            return reject(error);
+        }
+        resolve(data);
+    };
+}
+
+function convertGLSL(code) {
+    return 'module.exports = `\n' + code + '`;';
+}

--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
   "name": "2gl",
-  "version": "0.0.16",
+  "version": "0.0.22",
   "description": "WebGL library for 2GIS projects",
   "repository": {
     "type": "git",
     "url": "git@github.com:2gis/2gl.git"
   },
-  "main": "src/index.js",
+  "main": "index.js",
+  "license" : "SEE LICENSE IN FILE",
   "dependencies": {
-    "babel-preset-es2015": "^6.3.13",
-    "babelify": "^7.2.0",
-    "brfs": "^1.4.1",
-    "browserify": "^12.0.1",
-    "gl-matrix": "^2.3.1",
-    "uglify-js": "^2.6.1"
+    "gl-matrix": "^2.3.1"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",
-    "babel-eslint": "^5.0.0-beta4",
+    "babel-eslint": "^5.0.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
+    "chokidar-cli": "^1.2.0",
     "coveralls": "^2.11.4",
     "dat-gui": "^0.5.0",
     "eslint": "^1.10.3",
@@ -27,22 +28,28 @@
     "minami": "git://github.com/Trufi/minami.git",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",
+    "uglify-js": "^2.6.1",
     "watchify": "^3.6.1"
   },
   "browserify": {
     "transform": [
-      "babelify",
-      "brfs"
+      "babelify"
     ]
   },
   "scripts": {
-    "postinstall": "mkdir -p dist && npm run build",
     "start": "npm run dev",
-    "build": "browserify src/index.js -s dgl | uglifyjs -mc --screw-ie8 > dist/2gl.js",
-    "dev": "watchify src/index.js -s dgl -o dist/2gl.js -dv",
+    "build": "npm run build:shaders && npm run build:dist",
+    "build:shaders": "node buildShaders.js",
+    "build:dist": "mkdir -p dist && browserify src/index.js -s dgl | uglifyjs -m -c --screw-ie8 > dist/2gl.js",
+    "build:es5": "babel src --out-dir=.",
+    "dev": "npm run dev:dist & npm run dev:shaders",
+    "dev:dist": "mkdir -p dist && watchify src/index.js -s dgl -o dist/2gl.js -dv",
+    "dev:shaders": "chokidar 'src/**/*.glsl' -c 'npm run build:shaders'",
+    "dev:es5": "babel --watch src --out-dir=.",
     "lint": "eslint src test",
     "doc": "./node_modules/.bin/jsdoc src -r -R README.md -t node_modules/minami -c jsdoc.json -d docs",
-    "test": "./node_modules/babel-cli/bin/babel-node.js ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha -- test/*.spec.js test/**/*.spec.js",
-    "test:dev": "./node_modules/.bin/_mocha --compilers js:babel-register -w test/*.spec.js test/**/*.spec.js"
+    "test": "npm run build:shaders && ./node_modules/babel-cli/bin/babel-node.js ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha -- test/*.spec.js test/**/*.spec.js",
+    "test:dev": "./node_modules/.bin/_mocha --compilers js:babel-register -w test/*.spec.js test/**/*.spec.js",
+    "pub": "npm run build && npm run build:es5 && npm publish && git clean -d -f"
   }
 }

--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -1,20 +1,14 @@
-// brfs module has error with import then using require
-/* eslint-disable no-var */
-var fs = require('fs');
-var path = require('path');
-/* eslint-enable no-var */
-
 export const basic = {
-    vertex: fs.readFileSync(path.join(__dirname, '/basic.vert.glsl'), 'utf8'),
-    fragment: fs.readFileSync(path.join(__dirname, '/basic.frag.glsl'), 'utf8')
+    vertex: require('./basic.vert.js'),
+    fragment: require('./basic.frag.js')
 };
 
 export const complex = {
-    vertex: fs.readFileSync(path.join(__dirname, '/complex.vert.glsl'), 'utf8'),
-    fragment: fs.readFileSync(path.join(__dirname, '/complex.frag.glsl'), 'utf8')
+    vertex: require('./complex.vert.js'),
+    fragment: require('./complex.frag.js')
 };
 
 export const sprite = {
-    vertex: fs.readFileSync(path.join(__dirname, '/sprite.vert.glsl'), 'utf8'),
-    fragment: fs.readFileSync(path.join(__dirname, '/sprite.frag.glsl'), 'utf8')
+    vertex: require('./sprite.vert.js'),
+    fragment: require('./sprite.frag.js')
 };


### PR DESCRIPTION
Убрал `brfs`, теперь его работу выполняет скрипт `buildShaders`, который ищёт файлы шейдеров и в том же месте создаёт js, экспортящий шейдер как текст.
Это позволяет назависеть от сборщика `browserify`/`webpack`, а также проект можно просто прогнать с помощью `babel` и запаблишить в нпм, как валидный es5 код.

В чём профит?
1. В нпм добавляются уже транспилированые в es5 файлы и ничего лишнего, соответсвенно либа ставится очень быстро. Также доступна собранная версия `dist/2gl.js`.
2. Другие проекты использующие `2gl` не зависят от сборки `2gl`
3. Такая структура в дальнейшем позволяет сделать библиотеку модульной, т.е. реквайрить самое необходимое, например `require('2gl/sprite')`

Почему `npm run pub`, а не `npm publish` с использованием `prebulish`? Потому, что `prebulish` скрипт вызывается каждый раз после `npm i` в корне либы https://github.com/npm/npm/issues/3059
