### PR TITLE
Add shader program

### DIFF
--- a/src/MultiSprite.js
+++ b/src/MultiSprite.js
@@ -160,14 +160,17 @@ class MultiSprite extends Object3D {
     }
 
     render(state) {
-        const {gl, attributes} = state;
+        const {gl, shaderProgram} = state;
+        const geometry = this._geometry;
 
-        this._geometry.getBuffer('texture').bind(gl, attributes.texture);
-        this._geometry.getBuffer('position').bind(gl, attributes.position);
-        this._geometry.getBuffer('colorAlpha').bind(gl, attributes.colorAlpha);
-        this._geometry.getBuffer('scale').bind(gl, attributes.scale);
-        this._geometry.getBuffer('offset').bind(gl, attributes.offset);
-        this._geometry.getBuffer('disposition').bind(gl, attributes.disposition);
+        shaderProgram.bind(gl, null, {
+            texture: geometry.getBuffer('texture'),
+            position: geometry.getBuffer('position'),
+            colorAlpha: geometry.getBuffer('colorAlpha'),
+            scale: geometry.getBuffer('scale'),
+            offset: geometry.getBuffer('offset'),
+            disposition: geometry.getBuffer('disposition')
+        });
 
         for (const key in this._data) {
             if (this._data[key].dirty) {

--- a/src/ShaderAttribute.js
+++ b/src/ShaderAttribute.js
@@ -1,0 +1,47 @@
+/**
+ * Шейдерный атрибут, используется только {@link ShaderProgram}
+ *
+ * @param {AttributeDefinition} options
+ * @ignore
+ */
+class ShaderAttribute {
+    constructor(options) {
+        this.name = options.name;
+        this.index = options.index;
+        this.location = -1;
+    }
+
+    setLocation(gl, shaderProgram) {
+        this.location = gl.getAttribLocation(shaderProgram, this.name);
+        return this;
+    }
+
+    enable(gl) {
+        if (this.index !== true) {
+            gl.enableVertexAttribArray(this.location);
+        }
+        return this;
+    }
+
+    bind(gl, buffer) {
+        buffer.bind(gl, this.location);
+        return this;
+    }
+
+    disable(gl) {
+        if (this.index !== true) {
+            gl.disableVertexAttribArray(this.location);
+        }
+        return this;
+    }
+}
+
+module.exports = ShaderAttribute;
+
+/**
+ * Описание шейдерного атрибута
+ *
+ * @typedef {Object} AttributeDefinition
+ * @property {String} name Название атрибута
+ * @property {Boolean} [index] Если атрибут используется для передачи индексов, то true
+ */

--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -1,0 +1,165 @@
+import ShaderAttribute from './ShaderAttribute';
+import ShaderUniform from './ShaderUniform';
+
+/**
+ * Шейдерная программа инициализирует шейдеры, подготавливает и связывает данные с WebGL.
+ *
+ * @param {Object} options
+ * @param {String} vertex Код вершинного шейдера
+ * @param {String} fragment Код фрагментного шейдера
+ * @param {UniformDefinition[]} [options.uniforms=[]] Описание юниформ
+ * @param {AttributeDefinition[]} [options.attributes=[]] Описание атрибутов
+ * @param {Object[]} [options.definitions=[]]
+ */
+class ShaderProgram {
+    constructor(options) {
+        options = options || {};
+
+        this._vertexShaderCode = options.vertex || '';
+        this._fragmentShaderCode = options.fragment || '';
+
+        this._uniforms = {};
+        options.uniforms = options.uniforms || [];
+        options.uniforms.forEach(obj => {
+            this._uniforms[obj.name] = new ShaderUniform(obj);
+        });
+
+        this._attributes = {};
+        options.attributes = options.attributes || [];
+        options.attributes.forEach(obj => {
+            this._attributes[obj.name] = new ShaderAttribute(obj);
+        });
+
+        this._definitions = options.definitions || [];
+
+        this._status = ShaderProgram.NOT_READY;
+    }
+
+    /**
+     * Инициализирует программу с контекстом WebGl
+     *
+     * @param {WebGLRenderingContext} gl
+     */
+    enable(gl) {
+        if (this._status === ShaderProgram.NOT_READY) {
+            this._prepare(gl);
+        }
+
+        if (this._status !== ShaderProgram.READY) { return this; }
+
+        gl.useProgram(this._webglProgram);
+
+        for (const name in this._attributes) {
+            this._attributes[name].enable(gl);
+        }
+
+        return this;
+    }
+
+    /**
+     * Связывает юниформы и атрибуты программы с контекстом WebGl
+     *
+     * @param {WebGLRenderingContext} gl
+     * @param {Object} [uniforms] Key-value объект содержащий значения юниформ
+     * @param {Object} [attributes] Key-value объект содержащий значения атрибутов
+     */
+    bind(gl, uniforms, attributes) {
+        if (uniforms) {
+            for (const name in uniforms) {
+                this._uniforms[name].bind(gl, uniforms[name]);
+            }
+        }
+
+        if (attributes) {
+            for (const name in attributes) {
+                this._attributes[name].bind(gl, attributes[name]);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Выключает программу
+     *
+     * @param {WebGLRenderingContext} gl
+     */
+    disable(gl) {
+        for (const name in this._attributes) {
+            this._attributes[name].disable(gl);
+        }
+
+        return this;
+    }
+
+    _prepare(gl) {
+        this._prepareShaders(gl);
+        this._prepareAttributes(gl);
+        this._prepareUniforms(gl);
+    }
+
+    _prepareShaders(gl) {
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShader, this._addDefinitions(this._fragmentShaderCode));
+        gl.compileShader(fragmentShader);
+
+        if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+            console.log(gl.getShaderInfoLog(fragmentShader));
+            this._status = ShaderProgram.FAILED;
+            return;
+        }
+
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShader, this._addDefinitions(this._vertexShaderCode));
+        gl.compileShader(vertexShader);
+
+        if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+            console.log(gl.getShaderInfoLog(vertexShader));
+            this._status = ShaderProgram.FAILED;
+            return;
+        }
+
+        this._webglProgram = gl.createProgram();
+        gl.attachShader(this._webglProgram, vertexShader);
+        gl.attachShader(this._webglProgram, fragmentShader);
+        gl.linkProgram(this._webglProgram);
+
+        if (!gl.getProgramParameter(this._webglProgram, gl.LINK_STATUS)) {
+            console.log('Could not initialize shaders');
+            this._status = ShaderProgram.FAILED;
+            return;
+        }
+
+        this._status = ShaderProgram.READY;
+        this._fragmentShaderCode = null;
+        this._vertexShaderCode = null;
+    }
+
+    _addDefinitions(shader) {
+        return this._definitions.map(def => {
+            if (def.value !== undefined) {
+                return '#define ' + def.type + ' ' + def.value;
+            } else {
+                return '#define ' + def.type;
+            }
+        }).join('\n') + '\n' + shader;
+    }
+
+    _prepareAttributes(gl) {
+        for (const name in this._attributes) {
+            this._attributes[name].setLocation(gl, this._webglProgram);
+        }
+    }
+
+    _prepareUniforms(gl) {
+        for (const name in this._uniforms) {
+            this._uniforms[name].setLocation(gl, this._webglProgram);
+        }
+    }
+}
+
+ShaderProgram.NOT_READY = 1;
+ShaderProgram.READY = 2;
+ShaderProgram.FAILED = 3;
+
+module.exports = ShaderProgram;

--- a/src/ShaderUniform.js
+++ b/src/ShaderUniform.js
@@ -1,0 +1,56 @@
+/**
+ * Шейдерная юниформа, используется только {@link ShaderProgram}
+ *
+ * @param {UniformDefinition} options
+ * @ignore
+ */
+class ShaderUniform {
+    constructor(options) {
+        this.name = options.name;
+        this.type = options.type;
+        this.location = -1;
+    }
+
+    setLocation(gl, webglProgram) {
+        this.location = gl.getUniformLocation(webglProgram, this.name);
+        return this;
+    }
+
+    bind(gl, value) {
+        const type = this.type;
+
+        if (type === 'mat2') {
+            gl.uniformMatrix2fv(this.location, false, value);
+        } else if (type === 'mat3') {
+            gl.uniformMatrix3fv(this.location, false, value);
+        } else if (type === 'mat4') {
+            gl.uniformMatrix4fv(this.location, false, value);
+        } else if (type === '2f') {
+            gl.uniform2f(this.location, value[0], value[1]);
+        } else if (type === '3f') {
+            gl.uniform3f(this.location, value[0], value[1], value[2]);
+        } else if (type === '4f') {
+            gl.uniform4f(this.location, value[0], value[1], value[2], value[3]);
+        } else if (type === '2i') {
+            gl.uniform2i(this.location, value[0], value[1]);
+        } else if (type === '3i') {
+            gl.uniform3i(this.location, value[0], value[1], value[2]);
+        } else if (type === '4i') {
+            gl.uniform4i(this.location, value[0], value[1], value[2], value[3]);
+        } else {
+            gl['uniform' + type](this.location, value);
+        }
+
+        return this;
+    }
+}
+
+module.exports = ShaderUniform;
+
+/**
+ * Описание шейдерной юниформы
+ *
+ * @typedef {Object} UniformDefinition
+ * @property {String} name Название юниформы
+ * @property {String} type Тип юниформы, может быть: mat[234], [1234][fi], [1234][fi]v
+ */

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -50,16 +50,15 @@ class Texture {
      * @param {WebGLRenderingContext} gl
      * @param {Number} uniform
      */
-    enable(gl, uniform) {
+    enable(gl, isActivate) {
         if (!this._texture) {
             this._prepare(gl);
         }
 
         gl.bindTexture(gl.TEXTURE_2D, this._texture);
 
-        if (uniform) {
+        if (isActivate) {
             gl.activeTexture(gl.TEXTURE0);
-            gl.uniform1i(uniform, 0);
         }
 
         return this;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -48,16 +48,16 @@ class Texture {
      * При первом вызов происходит инициализация.
      *
      * @param {WebGLRenderingContext} gl
-     * @param {Number} uniform
+     * @param {Boolean} activate Нужно ли делать текстуру активной в контексте WebGL
      */
-    enable(gl, isActivate) {
+    enable(gl, activate) {
         if (!this._texture) {
             this._prepare(gl);
         }
 
         gl.bindTexture(gl.TEXTURE_2D, this._texture);
 
-        if (isActivate) {
+        if (activate) {
             gl.activeTexture(gl.TEXTURE0);
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import PerspectiveCamera from './cameras/PerspectiveCamera';
 import OrthographicCamera from './cameras/OrthographicCamera';
 import Buffer from './Buffer';
 import Geometry from './Geometry';
+import ShaderProgram from './ShaderProgram';
 import BasicMeshProgram from './programs/BasicMeshProgram';
 import ComplexMeshProgram from './programs/ComplexMeshProgram';
 import SpriteProgram from './programs/SpriteProgram';
@@ -38,6 +39,7 @@ const dgl = {
     Mesh,
     Sprite,
     MultiSprite,
+    ShaderProgram,
     BasicMeshProgram,
     ComplexMeshProgram,
     SpriteProgram,

--- a/src/programs/BasicMeshProgram.js
+++ b/src/programs/BasicMeshProgram.js
@@ -11,8 +11,14 @@ class BasicMeshProgram extends Program {
     constructor() {
         super();
 
-        this._attributeList = ['position'];
-        this._uniformList = ['uCamera', 'uPosition', 'uColor', 'uColorAlpha'];
+        this._attributes = [{name: 'position'}];
+        this._uniforms = [
+            {name: 'uColorAlpha', type: '1f'},
+            {name: 'uCamera', type: 'mat4'},
+            {name: 'uPosition', type: 'mat4'},
+            {name: 'uColor', type: '3fv'}
+        ];
+
         this._shader = shader;
 
         /**
@@ -22,11 +28,20 @@ class BasicMeshProgram extends Program {
         this.color = [0, 0, 0];
     }
 
-    _bindUniforms({gl, camera, object}) {
-        gl.uniformMatrix4fv(this.uniforms.uPosition, false, new Float32Array(object.worldMatrix));
-        gl.uniformMatrix4fv(this.uniforms.uCamera, false, new Float32Array(camera.modelViewMatrix));
-        gl.uniform1f(this.uniforms.uColorAlpha, this.opacity);
-        gl.uniform3fv(this.uniforms.uColor, this.color);
+    _shaderProgramBind({gl, object, camera}) {
+        const attributes = {};
+        this._attributes.forEach(obj => {
+            attributes[obj.name] = object.geometry.getBuffer(obj.name);
+        });
+
+        const uniforms = {
+            uColorAlpha: this.opacity,
+            uPosition: new Float32Array(object.worldMatrix),
+            uCamera: new Float32Array(camera.modelViewMatrix),
+            uColor: this.color
+        };
+
+        this._shaderProgram.bind(gl, uniforms, attributes);
     }
 }
 

--- a/src/programs/MultiSpriteProgram.js
+++ b/src/programs/MultiSpriteProgram.js
@@ -27,8 +27,10 @@ class MultiSpriteProgram {
         return this._texture;
     }
 
-    enable({gl, object, uniforms, renderer}) {
-        gl.uniform1f(uniforms.uSmoothing, this.smoothing);
+    enable({gl, shaderProgram}) {
+        shaderProgram.bind(gl, {
+            uSmoothing: this.smoothing
+        });
 
         if (this._texture) {
             this._texture.enable(gl);

--- a/src/programs/SpriteProgram.js
+++ b/src/programs/SpriteProgram.js
@@ -28,15 +28,17 @@ class SpriteProgram {
         return this._texture;
     }
 
-    enable({gl, object, uniforms, renderer}) {
-        gl.uniform1f(uniforms.uColorAlpha, this.opacity);
-        gl.uniform1f(uniforms.uSmoothing, this.smoothing);
-
+    enable({gl, object, shaderProgram, renderer}) {
         const size = renderer.getSize();
-        gl.uniform2f(uniforms.uHalfSize, size[0] / 2, size[1] / 2);
-        gl.uniform2f(uniforms.uOffset, object.offset[0], object.offset[1]);
-        gl.uniform2f(uniforms.uScale, object.scale[0], object.scale[1]);
-        gl.uniform3f(uniforms.uPosition, object.worldMatrix[12], object.worldMatrix[13], object.worldMatrix[14]);
+
+        shaderProgram.bind(gl, {
+            uColorAlpha: this.opacity,
+            uSmoothing: this.smoothing,
+            uHalfSize: [size[0] / 2, size[1] / 2],
+            uOffset: object.offset,
+            uScale: object.scale,
+            uPosition: [object.worldMatrix[12], object.worldMatrix[13], object.worldMatrix[14]]
+        });
 
         if (this._texture) {
             this._texture.enable(gl);

--- a/src/renderer/MultiSpriteRenderer.js
+++ b/src/renderer/MultiSpriteRenderer.js
@@ -1,4 +1,5 @@
 import {multiSprite as shader} from '../shaders';
+import ShaderProgram from '../ShaderProgram';
 
 /**
  * Отдельный рендер, используется для отрисовки мультиспрайтов.
@@ -8,10 +9,32 @@ class MultiSpriteRenderer {
     constructor(renderer) {
         this._renderer = renderer;
         this._shader = shader;
+
+        this._shaderProgram = new ShaderProgram({
+            vertex: shader.vertex,
+            fragment: shader.fragment,
+            uniforms: [
+                {name: 'uPCamera', type: 'mat4'},
+                {name: 'uHalfSize', type: '2f'},
+                {name: 'uTexture', type: '1i'},
+                {name: 'uSmoothing', type: '1f'}
+            ],
+            attributes: [
+                {name: 'disposition'},
+                {name: 'texture'},
+                {name: 'position'},
+                {name: 'colorAlpha'},
+                {name: 'scale'},
+                {name: 'offset'}
+            ]
+        });
     }
 
     render(state, renderObjects) {
+        const size = this._renderer.getSize();
         const {gl, camera} = state;
+
+        state.shaderProgram = this._shaderProgram;
 
         gl.disable(gl.DEPTH_TEST);
 
@@ -19,81 +42,21 @@ class MultiSpriteRenderer {
         gl.blendEquation(gl.FUNC_ADD);
         gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
-        if (!this._shaderProgram) {
-            this._prepare(state);
-        }
-
-        gl.useProgram(this._shaderProgram);
-
-        gl.enableVertexAttribArray(this._attributes.disposition);
-        gl.enableVertexAttribArray(this._attributes.texture);
-        gl.enableVertexAttribArray(this._attributes.position);
-        gl.enableVertexAttribArray(this._attributes.colorAlpha);
-        gl.enableVertexAttribArray(this._attributes.scale);
-        gl.enableVertexAttribArray(this._attributes.offset);
-
-        state.attributes = this._attributes;
-        state.uniforms = this._uniforms;
-
-        gl.uniformMatrix4fv(this._uniforms.uPCamera, false, new Float32Array(camera.modelViewMatrix));
-
-        const size = this._renderer.getSize();
-        gl.uniform2f(this._uniforms.uHalfSize, size[0] / 2, size[1] / 2);
+        this._shaderProgram
+            .enable(gl)
+            .bind(gl, {
+                uPCamera: new Float32Array(camera.modelViewMatrix),
+                uHalfSize: [size[0] / 2, size[1] / 2],
+                uTexture: 0
+            });
 
         gl.activeTexture(gl.TEXTURE0);
-        gl.uniform1i(this._uniforms.uTexture, 0);
 
         renderObjects.forEach(object => object.render(state));
 
-        gl.disableVertexAttribArray(this._attributes.disposition);
-        gl.disableVertexAttribArray(this._attributes.texture);
-        gl.disableVertexAttribArray(this._attributes.position);
-        gl.disableVertexAttribArray(this._attributes.colorAlpha);
-        gl.disableVertexAttribArray(this._attributes.scale);
-        gl.disableVertexAttribArray(this._attributes.offset);
+        this._shaderProgram.disable(gl);
 
         return this;
-    }
-
-    _prepare(state) {
-        this._prepareShaders(state);
-        this._prepareAttributes(state);
-        this._prepareUniforms(state);
-    }
-
-    _prepareShaders({gl}) {
-        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-        gl.shaderSource(fragmentShader, this._shader.fragment);
-        gl.compileShader(fragmentShader);
-
-        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-        gl.shaderSource(vertexShader, this._shader.vertex);
-        gl.compileShader(vertexShader);
-
-        this._shaderProgram = gl.createProgram();
-        gl.attachShader(this._shaderProgram, vertexShader);
-        gl.attachShader(this._shaderProgram, fragmentShader);
-        gl.linkProgram(this._shaderProgram);
-    }
-
-    _prepareAttributes({gl}) {
-        this._attributes = {
-            disposition: gl.getAttribLocation(this._shaderProgram, 'disposition'),
-            texture: gl.getAttribLocation(this._shaderProgram, 'texture'),
-            position: gl.getAttribLocation(this._shaderProgram, 'position'),
-            colorAlpha: gl.getAttribLocation(this._shaderProgram, 'colorAlpha'),
-            scale: gl.getAttribLocation(this._shaderProgram, 'scale'),
-            offset: gl.getAttribLocation(this._shaderProgram, 'offset')
-        };
-    }
-
-    _prepareUniforms({gl}) {
-        this._uniforms = {
-            uPCamera: gl.getUniformLocation(this._shaderProgram, 'uPCamera'),
-            uHalfSize: gl.getUniformLocation(this._shaderProgram, 'uHalfSize'),
-            uTexture: gl.getUniformLocation(this._shaderProgram, 'uTexture'),
-            uSmoothing: gl.getUniformLocation(this._shaderProgram, 'uSmoothing')
-        };
     }
 }
 

--- a/test/MultiSprite.spec.js
+++ b/test/MultiSprite.spec.js
@@ -3,6 +3,7 @@ import {slice, getRenderState} from './utils';
 import sinon from 'sinon';
 
 import MultiSpriteProgram from '../src/programs/MultiSpriteProgram';
+import ShaderProgram from '../src/ShaderProgram';
 import Object3D from '../src/Object3D';
 import Texture from '../src/Texture';
 
@@ -49,17 +50,22 @@ describe('MultiSprite', () => {
         beforeEach(() => {
             state = getRenderState();
             state.object = multiSprite;
-            state.attributes = {
-                texture: 1,
-                colorAlpha: 2,
-                offset: 3,
-                scale: 4,
-                position: 5
-            };
-            state.uniforms = {
-                uSmoothing: 3,
-                uHalfSize: 4
-            };
+            state.shaderProgram = new ShaderProgram({
+                uniforms: [
+                    {name: 'uPCamera', type: 'mat4'},
+                    {name: 'uHalfSize', type: '2f'},
+                    {name: 'uTexture', type: '1i'},
+                    {name: 'uSmoothing', type: '1f'}
+                ],
+                attributes: [
+                    {name: 'disposition'},
+                    {name: 'texture'},
+                    {name: 'position'},
+                    {name: 'colorAlpha'},
+                    {name: 'scale'},
+                    {name: 'offset'}
+                ]
+            });
             state.renderer = {
                 getSize: () => [100, 50]
             };

--- a/test/ShaderAttributes.spec.js
+++ b/test/ShaderAttributes.spec.js
@@ -1,0 +1,66 @@
+import ShaderAttribute from '../src/ShaderAttribute';
+import GlContext from './utils/GlContext';
+import assert from 'assert';
+import sinon from 'sinon';
+
+describe('ShaderAttribute', () => {
+    let gl;
+
+    beforeEach(() => {
+        gl = new GlContext();
+    });
+
+    describe('#enable', () => {
+        it('should call gl enableVertexAttribArray by default', () => {
+            const spy = sinon.spy(gl, 'enableVertexAttribArray');
+
+            const shaderAttribute = new ShaderAttribute({
+                name: 'testName'
+            });
+
+            shaderAttribute.enable(gl);
+
+            assert.ok(spy.calledOnce);
+        });
+
+        it('shouldn\'t call gl enableVertexAttribArray if type = index', () => {
+            const spy = sinon.spy(gl, 'enableVertexAttribArray');
+
+            const shaderAttribute = new ShaderAttribute({
+                name: 'testName',
+                index: true
+            });
+
+            shaderAttribute.enable(gl);
+
+            assert.ok(!spy.called);
+        });
+    });
+
+    describe('#disable', () => {
+        it('should call gl disableVertexAttribArray by default', () => {
+            const spy = sinon.spy(gl, 'disableVertexAttribArray');
+
+            const shaderAttribute = new ShaderAttribute({
+                name: 'testName'
+            });
+
+            shaderAttribute.disable(gl);
+
+            assert.ok(spy.calledOnce);
+        });
+
+        it('shouldn\'t call gl disableVertexAttribArray if type = index', () => {
+            const spy = sinon.spy(gl, 'disableVertexAttribArray');
+
+            const shaderAttribute = new ShaderAttribute({
+                name: 'testName',
+                index: true
+            });
+
+            shaderAttribute.disable(gl);
+
+            assert.ok(!spy.called);
+        });
+    });
+});

--- a/test/ShaderProgram.spec.js
+++ b/test/ShaderProgram.spec.js
@@ -1,0 +1,78 @@
+import ShaderProgram from '../src/ShaderProgram';
+import GlContext from './utils/GlContext';
+import assert from 'assert';
+import sinon from 'sinon';
+
+describe('ShaderProgram', () => {
+    let gl;
+
+    beforeEach(() => {
+        gl = new GlContext();
+    });
+
+    describe('#constructor', () => {
+        it('should work with empty options', () => {
+            const program = new ShaderProgram();
+            assert.ok(program);
+        });
+    });
+
+    describe('#enable', () => {
+        let program;
+
+        beforeEach(() => {
+            program = new ShaderProgram();
+        });
+
+        it('should create two shaders', () => {
+            const spy = sinon.spy(gl, 'createShader');
+            program.enable(gl);
+            assert.ok(spy.calledTwice);
+        });
+
+        it('should create program', () => {
+            const spy = sinon.spy(gl, 'createProgram');
+            program.enable(gl);
+            assert.ok(spy.calledOnce);
+        });
+
+        it('should use program', () => {
+            const spy = sinon.spy(gl, 'useProgram');
+            program.enable(gl);
+            assert.ok(spy.calledOnce);
+        });
+
+        it('shouldn\'t create shaders after first call', () => {
+            const spy = sinon.spy(gl, 'createShader');
+            program.enable(gl);
+            program.enable(gl);
+            assert.ok(spy.calledTwice);
+        });
+
+        it('shouldn\'t create program after first call', () => {
+            const spy = sinon.spy(gl, 'createProgram');
+            program.enable(gl);
+            program.enable(gl);
+            assert.ok(spy.calledOnce);
+        });
+    });
+
+    describe('#bind', () => {
+        it('should work with different arguments', () => {
+            const program = new ShaderProgram();
+            program.bind(gl);
+            program.bind(gl, {});
+            program.bind(gl, {}, {});
+            program.bind(gl, null, {});
+        });
+    });
+
+    describe('#disable', () => {
+        it('should work', () => {
+            const program = new ShaderProgram();
+            program.disable(gl);
+            program.enable(gl);
+            program.disable(gl);
+        });
+    });
+});

--- a/test/ShaderUniform.spec.js
+++ b/test/ShaderUniform.spec.js
@@ -1,0 +1,31 @@
+import ShaderUniform from '../src/ShaderUniform';
+import GlContext from './utils/GlContext';
+
+describe('ShaderUniform', () => {
+    let gl;
+
+    beforeEach(() => {
+        gl = new GlContext();
+    });
+
+    describe('#bind', () => {
+        const types = [
+            'mat2', 'mat3', 'mat4',
+            '1f', '2f', '3f', '4f',
+            '1i', '2i', '3i', '4i',
+            '1fv', '2fv', '3fv', '4fv',
+            '1iv', '2iv', '3iv', '4iv'
+        ];
+
+        types.forEach(type => {
+            it(`should work with ${type} type`, () => {
+                const uniform = new ShaderUniform({
+                    name: 'testName',
+                    type: type
+                });
+
+                uniform.bind(gl, []);
+            });
+        });
+    });
+});

--- a/test/Sprite.spec.js
+++ b/test/Sprite.spec.js
@@ -3,6 +3,7 @@ import {slice, getRenderState} from './utils';
 import sinon from 'sinon';
 
 import SpriteProgram from '../src/programs/SpriteProgram';
+import ShaderProgram from '../src/ShaderProgram';
 import Object3D from '../src/Object3D';
 import Texture from '../src/Texture';
 
@@ -37,14 +38,23 @@ describe('Sprite', () => {
         beforeEach(() => {
             state = getRenderState();
             state.object = sprite;
-            state.uniforms = {
-                uColorAlpha: 1,
-                uSmoothing: 2,
-                uHalfSize: 3,
-                uOffset: 4,
-                uScale: 5,
-                uPosition: 6
-            };
+            state.shaderProgram = new ShaderProgram({
+                uniforms: [
+                    {name: 'uPCamera', type: 'mat4'},
+                    {name: 'uPosition', type: '3f'},
+                    {name: 'uColorAlpha', type: '1f'},
+                    {name: 'uScale', type: '2f'},
+                    {name: 'uTexture', type: '1i'},
+                    {name: 'uHalfSize', type: '2f'},
+                    {name: 'uOffset', type: '2f'},
+                    {name: 'uSmoothing', type: '1f'}
+                ],
+                attributes: [
+                    {name: 'position'},
+                    {name: 'texture'},
+                    {name: 'index', index: true}
+                ]
+            });
             state.renderer = {
                 getSize: () => [100, 50]
             };

--- a/test/Texture.spec.js
+++ b/test/Texture.spec.js
@@ -72,7 +72,7 @@ describe('Texture', () => {
             assert.ok(spy.calledTwice);
         });
 
-        it('shouldn\'t activate texture if not put uniform', () => {
+        it('shouldn\'t activate texture if not put active', () => {
             const spy = sinon.spy(gl, 'activeTexture');
             texture.enable(gl);
             assert.ok(!spy.called);

--- a/test/programs/BasicMeshProgram.spec.js
+++ b/test/programs/BasicMeshProgram.spec.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import sinon from 'sinon';
 import {getRenderState, cubeVertices} from '../utils';
 import Mesh from '../../src/Mesh';
 import Program from '../../src/programs/Program';
@@ -9,15 +8,18 @@ import Buffer from '../../src/Buffer';
 import BasicMeshProgram from '../../src/programs/BasicMeshProgram';
 
 describe('BasicMeshProgram', () => {
-    let program, geometry, mesh;
+    let program, geometry, mesh, state;
 
     beforeEach(() => {
+        state = getRenderState();
         program = new BasicMeshProgram();
 
         geometry = new Geometry();
         geometry.setBuffer('position', new Buffer(new Float32Array(cubeVertices), 3));
 
         mesh = new Mesh(geometry, program);
+
+        state.object = mesh;
     });
 
     describe('#constructor', () => {
@@ -35,57 +37,14 @@ describe('BasicMeshProgram', () => {
     });
 
     describe('#enable', () => {
-        let state;
-
-        beforeEach(() => {
-            state = getRenderState();
-            state.object = mesh;
-        });
-
-        it('should create two shaders', () => {
-            const spy = sinon.spy(state.gl, 'createShader');
+        it('should exist', () => {
             program.enable(state);
-            assert.ok(spy.calledTwice);
-        });
-
-        it('should create program', () => {
-            const spy = sinon.spy(state.gl, 'createProgram');
-            program.enable(state);
-            assert.ok(spy.calledOnce);
-        });
-
-        it('should use program', () => {
-            const spy = sinon.spy(state.gl, 'useProgram');
-            program.enable(state);
-            assert.ok(spy.calledOnce);
-        });
-
-        it('shouldn\'t create shaders after first call', () => {
-            const spy = sinon.spy(state.gl, 'createShader');
-            program.enable(state);
-            program.enable(state);
-            assert.ok(spy.calledTwice);
-        });
-
-        it('shouldn\'t create program after first call', () => {
-            const spy = sinon.spy(state.gl, 'createProgram');
-            program.enable(state);
-            program.enable(state);
-            assert.ok(spy.calledOnce);
         });
     });
 
     describe('#disable', () => {
-        it('should call disableVertexAttribArray once', () => {
-            const state = getRenderState();
-            state.object = mesh;
-
-            program.enable(state);
-
-            const spy = sinon.spy(state.gl, 'disableVertexAttribArray');
+        it('should exist', () => {
             program.disable(state.gl);
-
-            assert.ok(spy.calledOnce);
         });
     });
 });

--- a/test/programs/Program.spec.js
+++ b/test/programs/Program.spec.js
@@ -1,12 +1,11 @@
 import assert from 'assert';
-import sinon from 'sinon';
 import {getRenderState} from '../utils';
 import Object3D from '../../src/Object3D';
 
 import Program from '../../src/programs/Program';
 
 describe('Program', () => {
-    let program;
+    let program, state;
 
     beforeEach(() => {
         program = new Program();
@@ -14,6 +13,7 @@ describe('Program', () => {
             fragment: '',
             vertex: ''
         };
+        state = getRenderState();
     });
 
     describe('#constructor', () => {
@@ -23,49 +23,14 @@ describe('Program', () => {
     });
 
     describe('#enable', () => {
-        let state;
-
-        beforeEach(() => {
-            state = getRenderState();
-            state.object = new Object3D();
-        });
-
-        it('should create two shaders', () => {
-            const spy = sinon.spy(state.gl, 'createShader');
+        it('should exist', () => {
             program.enable(state);
-            assert.ok(spy.calledTwice);
-        });
-
-        it('should create program', () => {
-            const spy = sinon.spy(state.gl, 'createProgram');
-            program.enable(state);
-            assert.ok(spy.calledOnce);
-        });
-
-        it('should use program', () => {
-            const spy = sinon.spy(state.gl, 'useProgram');
-            program.enable(state);
-            assert.ok(spy.calledOnce);
-        });
-
-        it('shouldn\'t create shaders after first call', () => {
-            const spy = sinon.spy(state.gl, 'createShader');
-            program.enable(state);
-            program.enable(state);
-            assert.ok(spy.calledTwice);
-        });
-
-        it('shouldn\'t create program after first call', () => {
-            const spy = sinon.spy(state.gl, 'createProgram');
-            program.enable(state);
-            program.enable(state);
-            assert.ok(spy.calledOnce);
         });
     });
 
     describe('#disable', () => {
-        it('should never do', () => {
-            program.disable();
+        it('should exist', () => {
+            program.disable(state.gl);
         });
     });
 

--- a/test/utils/GlContext.js
+++ b/test/utils/GlContext.js
@@ -121,14 +121,25 @@ GlContext.prototype.getUniformLocation = function() {
     return uniformCount++;
 };
 
+GlContext.prototype.uniformMatrix2fv = function() {};
+GlContext.prototype.uniformMatrix3fv = function() {};
 GlContext.prototype.uniformMatrix4fv = function() {};
 GlContext.prototype.uniform1f = function() {};
 GlContext.prototype.uniform2f = function() {};
 GlContext.prototype.uniform3f = function() {};
+GlContext.prototype.uniform4f = function() {};
 GlContext.prototype.uniform1i = function() {};
 GlContext.prototype.uniform2i = function() {};
 GlContext.prototype.uniform3i = function() {};
+GlContext.prototype.uniform4i = function() {};
+GlContext.prototype.uniform1fv = function() {};
+GlContext.prototype.uniform2fv = function() {};
 GlContext.prototype.uniform3fv = function() {};
+GlContext.prototype.uniform4fv = function() {};
+GlContext.prototype.uniform1iv = function() {};
+GlContext.prototype.uniform2iv = function() {};
+GlContext.prototype.uniform3iv = function() {};
+GlContext.prototype.uniform4iv = function() {};
 
 GlContext.prototype.drawArrays = function() {};
 GlContext.prototype.drawElements = function() {};


### PR DESCRIPTION
Добавил новую сущность `ShaderProgram`. Она инициализирует и связывает шейдеры, юниформы и атрибуты с WebGL.

Пример инициализации:
```js
const shaderProgram = new ShaderProgram({
    vertex: vertexCode,
    fragment: fragmentCode,
    uniforms: [
        {name: 'uPCamera', type: 'mat4'},
        {name: 'uTexture', type: '1i'},
    ],
    attributes: [
        {name: 'texture'},
        {name: 'position'},
    ]
});
```

* Метод `enable` включает программу и атрибуты.
* Метод `bind` связывает юниформы и атрибуты, причем можно передавать не все сразу, а по частям.
* Метод `disable` выключает атрибуты.

Все остальные компоненты переписал на использование шейдрной программы. Возможно, такие сущности как `BasicProgram`, `ComplexProgram` нужно переименовать теперь в `BasicMaterial`, `ComplexMaterial`.
