### PR TITLE
Support splitting shaders

### DIFF
--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -5,18 +5,18 @@ import ShaderUniform from './ShaderUniform';
  * Шейдерная программа инициализирует шейдеры, подготавливает и связывает данные с WebGL.
  *
  * @param {Object} options
- * @param {String} vertex Код вершинного шейдера
- * @param {String} fragment Код фрагментного шейдера
+ * @param {String | String[]} vertex Код вершинного шейдера. Либо строка, либо массив строк,
+ * которые последовательно складываются.
+ * @param {String | String[]} fragment Код фрагментного шейдера. Либо строка, либо массив строк,
+ * которые последовательно складываются.
  * @param {UniformDefinition[]} [options.uniforms=[]] Описание юниформ
  * @param {AttributeDefinition[]} [options.attributes=[]] Описание атрибутов
  * @param {Object[]} [options.definitions=[]]
  */
 class ShaderProgram {
-    constructor(options) {
-        options = options || {};
-
-        this._vertexShaderCode = options.vertex || '';
-        this._fragmentShaderCode = options.fragment || '';
+    constructor(options = {}) {
+        this._vertexShaderCode = this._getShaderCode(options.vertex);
+        this._fragmentShaderCode = this._getShaderCode(options.fragment);
 
         this._uniforms = {};
         options.uniforms = options.uniforms || [];
@@ -90,6 +90,10 @@ class ShaderProgram {
         }
 
         return this;
+    }
+
+    _getShaderCode(code) {
+        return Array.isArray(code) ? code.join('\n') : (code || '');
     }
 
     _prepare(gl) {

--- a/test/ShaderProgram.spec.js
+++ b/test/ShaderProgram.spec.js
@@ -55,6 +55,23 @@ describe('ShaderProgram', () => {
             program.enable(gl);
             assert.ok(spy.calledOnce);
         });
+
+        it('should concat shader code if passed array', () => {
+            const spy = sinon.spy(gl, 'shaderSource');
+            const program = new ShaderProgram({
+                vertex: [
+                    'float codeA = 1.0;',
+                    'float codeB = 2.0;'
+                ],
+                fragment: [
+                    'int codeA = 1;',
+                    'int codeB = 2;'
+                ]
+            });
+            program.enable(gl);
+            assert.equal(spy.args[0][1], '\nint codeA = 1;\nint codeB = 2;');
+            assert.equal(spy.args[1][1], '\nfloat codeA = 1.0;\nfloat codeB = 2.0;');
+        });
     });
 
     describe('#bind', () => {


### PR DESCRIPTION
Теперь в шейдерную программу можно передавать код шейдера не строкой, а массивом строк. Массив сложится и получится единый код.