### PR TITLE
Make buildshaders cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ npm-debug.log
 coverage
 docs
 dist
-*.vert.js
-*.frag.js
+*.glsl.js

--- a/.npmignore
+++ b/.npmignore
@@ -10,5 +10,4 @@ test
 .eslintrc
 .travis.yml
 jsdoc.json
-buildShaders.js
 .npmignore

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "main": "index.js",
   "license": "SEE LICENSE IN FILE",
+  "bin": {
+    "buildShaders": "buildShaders.js"
+  },
   "dependencies": {
     "gl-matrix": "2.3.1"
   },
@@ -39,7 +42,7 @@
   "scripts": {
     "start": "npm run dev",
     "build": "npm run build:shaders && npm run build:dist",
-    "build:shaders": "node buildShaders.js",
+    "build:shaders": "node buildShaders.js src",
     "build:dist": "mkdir -p dist && npm run build:dist:bundle && npm run build:dist:uglify",
     "build:dist:bundle": "browserify src/index.js -s dgl -d -o dist/2gl.js",
     "build:dist:uglify": "uglifyjs dist/2gl.js -mc --screw-ie8 --source-map dist/2gl.js.map -o dist/2gl.js",

--- a/src/materials/BasicMeshMaterial.js
+++ b/src/materials/BasicMeshMaterial.js
@@ -1,5 +1,5 @@
-import fragmentShader from '../shaders/basic.frag.js';
-import vertexShader from '../shaders/basic.vert.js';
+import fragmentShader from '../shaders/basic.frag.glsl.js';
+import vertexShader from '../shaders/basic.vert.glsl.js';
 import Material from './Material';
 import libConstants from '../libConstants';
 

--- a/src/materials/ComplexMeshMaterial.js
+++ b/src/materials/ComplexMeshMaterial.js
@@ -1,5 +1,5 @@
-import fragmentShader from '../shaders/complex.frag.js';
-import vertexShader from '../shaders/complex.vert.js';
+import fragmentShader from '../shaders/complex.frag.glsl.js';
+import vertexShader from '../shaders/complex.vert.glsl.js';
 import {vec3, mat3} from 'gl-matrix';
 import Material from './Material';
 import libConstants from '../libConstants';

--- a/src/rendererPlugins/MultiSpritePlugin.js
+++ b/src/rendererPlugins/MultiSpritePlugin.js
@@ -1,5 +1,5 @@
-import fragmentShader from '../shaders/multiSprite.frag.js';
-import vertexShader from '../shaders/multiSprite.vert.js';
+import fragmentShader from '../shaders/multiSprite.frag.glsl.js';
+import vertexShader from '../shaders/multiSprite.vert.glsl.js';
 import ShaderProgram from '../ShaderProgram';
 import RendererPlugin from '../RendererPlugin';
 import Renderer from '../Renderer';

--- a/src/rendererPlugins/SpritePlugin.js
+++ b/src/rendererPlugins/SpritePlugin.js
@@ -1,5 +1,5 @@
-import fragmentShader from '../shaders/sprite.frag.js';
-import vertexShader from '../shaders/sprite.vert.js';
+import fragmentShader from '../shaders/sprite.frag.glsl.js';
+import vertexShader from '../shaders/sprite.vert.glsl.js';
 import ShaderProgram from '../ShaderProgram';
 import RendererPlugin from '../RendererPlugin';
 import Geometry from '../Geometry';


### PR DESCRIPTION
Теперь `buildShaders` добавляется в `node_modules/.bin` и его можно запускать из консоли в других проектах для переделки шейдеров из glsl в js.