### PR TITLE
Tree shaker-shaker

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@ npm-debug.log
 coverage
 docs
 examples
-src
 test
 .babelrc
 .eslintrc

--- a/buildShaders.js
+++ b/buildShaders.js
@@ -124,5 +124,5 @@ function callback(resolve, reject) {
 }
 
 function convertGLSL(code) {
-    return 'module.exports = `\n' + code + '`;\n';
+    return 'export default `\n' + code + '`;\n';
 }

--- a/examples/basicMeshPerformance.html
+++ b/examples/basicMeshPerformance.html
@@ -99,7 +99,10 @@
         canvas: 'canvas'
     });
 
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer
+        .addPlugin(dgl.CommonPlugin)
+        .addPlugin(dgl.TransparentPlugin)
+        .setSize(window.innerWidth, window.innerHeight);
 
     window.addEventListener('resize', function() {
         stats.reset();

--- a/examples/complexMeshPerformance.html
+++ b/examples/complexMeshPerformance.html
@@ -146,7 +146,10 @@
         canvas: 'canvas'
     });
 
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer
+        .addPlugin(dgl.CommonPlugin)
+        .addPlugin(dgl.TransparentPlugin)
+        .setSize(window.innerWidth, window.innerHeight);
 
     window.addEventListener('resize', function() {
         stats.reset();

--- a/examples/multiSpritePerformance.html
+++ b/examples/multiSpritePerformance.html
@@ -116,7 +116,10 @@
         antialias: true
     });
 
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer
+        .addPlugin(dgl.MultiSpritePlugin)
+        .setSize(window.innerWidth, window.innerHeight);
+
     renderer.clearColor = [0.94, 0.94, 0.94, 1];
 
     window.addEventListener('resize', function() {

--- a/examples/spritePerformance.html
+++ b/examples/spritePerformance.html
@@ -83,7 +83,10 @@
         canvas: 'canvas'
     });
 
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer
+        .addPlugin(dgl.SpritePlugin)
+        .setSize(window.innerWidth, window.innerHeight);
+
     renderer.clearColor = [0.94, 0.94, 0.94, 1];
 
     window.addEventListener('resize', function() {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git@github.com:2gis/2gl.git"
   },
   "main": "index.js",
+  "jsnext:main": "src/index.js",
   "license": "SEE LICENSE IN FILE",
   "bin": {
     "buildShaders": "buildShaders.js"

--- a/src/Buffer.js
+++ b/src/Buffer.js
@@ -204,7 +204,7 @@ class Buffer {
         if (param === Buffer.ElementArrayBuffer) { return gl.ELEMENT_ARRAY_BUFFER; }
         if (param === Buffer.StaticDraw) { return gl.STATIC_DRAW; }
         if (param === Buffer.DynamicDraw) { return gl.DYNAMIC_DRAW; }
-        if (param === Buffer.Byte) { return gl.BYTE }
+        if (param === Buffer.Byte) { return gl.BYTE; }
         if (param === Buffer.Short) { return gl.SHORT; }
         if (param === Buffer.Int) { return gl.INT; }
         if (param === Buffer.Float) { return gl.FLOAT; }

--- a/src/MultiSprite.js
+++ b/src/MultiSprite.js
@@ -1,13 +1,14 @@
 import Object3D from './Object3D';
 import Geometry from './Geometry';
 import Buffer from './Buffer';
-import libConstants from './libConstants';
-import './rendererPlugins/MultiSpritePlugin';
+import {MULTI_SPRITE, MULTI_SPRITE_RENDERER} from './libConstants';
 
 /**
  * Используется для отрисовки мультиспрайтов. Мультиспрайт представляет собой множество
  * спрайтов, которые рисуются в один draw call. Спрайтами в мультиспрайте можно
  * управлять независимо друг от друга.
+ *
+ * Для отрисовки спрайтов нужно подключить {@link MultiSpritePlugin} к рендереру.
  *
  * @extends {Object3D}
  */
@@ -29,7 +30,7 @@ class MultiSprite extends Object3D {
          * Используется для обозначения типа объекта
          * @type {Number}
          */
-        this.type = libConstants.MULTI_SPRITE;
+        this.type = MULTI_SPRITE;
 
         this._initArrays(sprites);
         this._initGeometry();
@@ -204,7 +205,7 @@ class MultiSprite extends Object3D {
         // Если cпрайт невидим или у программы спрайта не установлена текстура, то не рендерим его
         if (!this.visible || !this.material.getTexture()) { return this; }
 
-        renderPlugins[libConstants.MULTI_SPRITE_RENDERER].addObject(this);
+        renderPlugins[MULTI_SPRITE_RENDERER].addObject(this);
 
         this.children.forEach(child => child.typifyForRender(renderPlugins));
 

--- a/src/Object3D.js
+++ b/src/Object3D.js
@@ -1,5 +1,5 @@
 import {vec3, mat4, quat} from 'gl-matrix';
-import {OBJECT_3D, COMMON_RENDERER} from './libConstants';
+import {OBJECT_3D, OBJECT_3D_RENDERER} from './libConstants';
 
 /**
  * Базовый класс для 3D объектов.
@@ -183,7 +183,7 @@ class Object3D {
     typifyForRender(renderPlugins) {
         if (!this.visible) { return this; }
 
-        renderPlugins[COMMON_RENDERER].addObject(this);
+        renderPlugins[OBJECT_3D_RENDERER].addObject(this);
 
         this.children.forEach(child => child.typifyForRender(renderPlugins));
 

--- a/src/Raycaster.js
+++ b/src/Raycaster.js
@@ -1,6 +1,6 @@
 import {vec3, mat3, mat4} from 'gl-matrix';
 import Ray from './math/Ray';
-import libConstants from './libConstants';
+import {MESH, PERSPECTIVE_CAMERA, ORTHOGRAPHIC_CAMERA} from './libConstants';
 
 /**
  * Позволяет легко определять пересечения луча с объектами.
@@ -24,7 +24,7 @@ class Raycaster {
          * @type {Object}
          */
         this.intersectMethodsByType = {
-            [libConstants.MESH]: 'intersectMesh'
+            [MESH]: 'intersectMesh'
         };
     }
 
@@ -36,7 +36,7 @@ class Raycaster {
      * @param {Camera} camera
      */
     setFromCamera(coordinates, camera) {
-        if (camera.type === libConstants.PERSPECTIVE_CAMERA) {
+        if (camera.type === PERSPECTIVE_CAMERA) {
             this.ray.origin = vec3.clone(camera.position);
 
             let direction = vec3.fromValues(coordinates[0], coordinates[1], 0.5);
@@ -45,7 +45,7 @@ class Raycaster {
             vec3.normalize(direction, direction);
             this.ray.direction = direction;
 
-        } else if (camera.type === libConstants.ORTHOGRAPHIC_CAMERA) {
+        } else if (camera.type === ORTHOGRAPHIC_CAMERA) {
             const origin = vec3.fromValues(coordinates[0], coordinates[1], -1);
             this.ray.origin = camera.unproject(origin);
 

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -236,7 +236,7 @@ class Renderer {
         // TODO: make state immutable?
 
         this._plugins.forEach(el => {
-            if (el.plugin.haveObjects()) {
+            if (el.plugin.hasObjects()) {
                 el.plugin.render(state);
             }
         });

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -1,3 +1,5 @@
+import Object3DPlugin from './rendererPlugins/Object3DPlugin';
+
 /**
  * Используется для инициализация WebGL контекста и отрисовки объектов.
  * Для некоторых объектов может использовать специфичные рендеры.
@@ -47,11 +49,50 @@ class Renderer {
 
         this._plugins = [];
         this._pluginsByType = {};
-        Renderer.plugins.forEach(el => {
-            const plugin = new el.Plugin(this);
-            this._plugins.push(plugin);
-            this._pluginsByType[plugin.type] = plugin;
+        this._maxPluginOrder = 0;
+
+        this.addPlugin(Object3DPlugin, 0);
+    }
+
+    /**
+     * Добавляет {@link RendererPlugin} к рендеру. К рендеру может быть добавлен только один плагин каждого типа.
+     * @param {Plugin} Plugin Класс плагина
+     * @param {?Number} order Каждый плагин выполняется при рендеринге по возрастанию order,
+     * если его нет, то выбирается максимальный order + 1.
+     */
+    addPlugin(Plugin, order) {
+        const plugin = new Plugin(this);
+
+        if (order === undefined) {
+            order = this._maxPluginOrder + 1;
+        }
+
+        this._plugins.push({
+            plugin,
+            order
         });
+        this._plugins.sort((a, b) => a.order - b.order);
+        this._pluginsByType[plugin.type] = plugin;
+
+        this._maxPluginOrder = Math.max.apply(Math, this._plugins.map(p => p.order));
+
+        return this;
+    }
+
+    /**
+     * Удаляет {@link RendererPlugin} из рендера.
+     * @param {Plugin} Plugin Класс плагина
+     */
+    removePlugin(Plugin) {
+        this._plugins.some((el, i) => {
+            if (el.plugin instanceof Plugin) {
+                delete this._pluginsByType[this._plugins[i].plugin.type];
+                this._plugins.splice(i, 1);
+                return true;
+            }
+        });
+
+        return this;
     }
 
     /**
@@ -194,9 +235,9 @@ class Renderer {
         };
         // TODO: make state immutable?
 
-        this._plugins.forEach(plugin => {
-            if (plugin.haveObjects()) {
-                plugin.render(state);
+        this._plugins.forEach(el => {
+            if (el.plugin.haveObjects()) {
+                el.plugin.render(state);
             }
         });
 
@@ -206,35 +247,7 @@ class Renderer {
 
         return this;
     }
-
-    /**
-     * Добавляет {@link RendererPlugin} к рендеру. К рендеру может быть добавлен только один плагин каждого типа.
-     * @param {Number} order Каждый плагин выполняется при рендеринге по возрастанию order
-     * @param {Plugin} Plugin Класс плагина
-     */
-    static addPlugin(order, Plugin) {
-        Renderer.plugins.push({
-            Plugin: Plugin,
-            order: order
-        });
-        Renderer.plugins.sort((a, b) => a.order - b.order);
-    }
-
-    /**
-     * Удаляет {@link RendererPlugin} из рендера.
-     * @param {Plugin} Plugin Класс плагина
-     */
-    static removePlugin(Plugin) {
-        Renderer.plugins.some((el, i) => {
-            if (el.Plugin === Plugin) {
-                Renderer.plugins.splice(i, 1);
-                return true;
-            }
-        });
-    }
 }
-
-Renderer.plugins = [];
 
 export default Renderer;
 

--- a/src/RendererPlugin.js
+++ b/src/RendererPlugin.js
@@ -32,7 +32,7 @@ class RendererPlugin {
         return this;
     }
 
-    haveObjects() {
+    hasObjects() {
         return this._objects.length > 0;
     }
 }

--- a/src/ShaderAttribute.js
+++ b/src/ShaderAttribute.js
@@ -36,7 +36,7 @@ class ShaderAttribute {
     }
 }
 
-module.exports = ShaderAttribute;
+export default ShaderAttribute;
 
 /**
  * Описание шейдерного атрибута

--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -124,4 +124,4 @@ ShaderProgram.NOT_READY = 1;
 ShaderProgram.READY = 2;
 ShaderProgram.FAILED = 3;
 
-module.exports = ShaderProgram;
+export default ShaderProgram;

--- a/src/ShaderUniform.js
+++ b/src/ShaderUniform.js
@@ -45,7 +45,7 @@ class ShaderUniform {
     }
 }
 
-module.exports = ShaderUniform;
+export default ShaderUniform;
 
 /**
  * Описание шейдерной юниформы

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -1,12 +1,13 @@
 import Object3D from './Object3D';
 import {vec2} from 'gl-matrix';
-import libConstants from './libConstants';
-import './rendererPlugins/SpritePlugin';
+import {SPRITE, SPRITE_RENDERER} from './libConstants';
 
 /**
  * Используется для отрисовки спрайтов. Спрайты всегда рисуются лицевой стороной
  * и их размеры не зависят от положения. Т.е. координаты спрайта проецируются в плоскость экрана,
  * и уже на ней отрисовываются.
+ *
+ * Для отрисовки спрайтов нужно подключить {@link SpritePlugin} к рендереру.
  *
  * @extends {Object3D}
  */
@@ -33,7 +34,7 @@ class Sprite extends Object3D {
          * Используется для обозначения типа объекта
          * @type {Number}
          */
-        this.type = libConstants.SPRITE;
+        this.type = SPRITE;
     }
 
     render(state) {
@@ -67,7 +68,7 @@ class Sprite extends Object3D {
     typifyForRender(renderPlugins) {
         if (!this.visible) { return this; }
 
-        renderPlugins[libConstants.SPRITE_RENDERER].addObject(this);
+        renderPlugins[SPRITE_RENDERER].addObject(this);
 
         this.children.forEach(child => child.typifyForRender(renderPlugins));
 

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -1,6 +1,6 @@
 import {mat4} from 'gl-matrix';
 import Camera from './Camera';
-import libConstants from '../libConstants';
+import {ORTHOGRAPHIC_CAMERA} from '../libConstants';
 
 /**
  * Задаёт орфографическую камеру
@@ -59,7 +59,7 @@ class OrthographicCamera extends Camera {
          * Используется для обозначения типа камеры
          * @type {Number}
          */
-        this.type = libConstants.ORTHOGRAPHIC_CAMERA;
+        this.type = ORTHOGRAPHIC_CAMERA;
     }
 
     updateProjectionMatrix() {

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -1,7 +1,7 @@
 import {mat4} from 'gl-matrix';
 import Camera from './Camera';
 import {degToRad} from '../math/Math';
-import libConstants from '../libConstants';
+import {PERSPECTIVE_CAMERA} from '../libConstants';
 
 /**
  * Задаёт перспективную камеру
@@ -46,7 +46,7 @@ class PerspectiveCamera extends Camera {
          * Используется для обозначения типа камеры
          * @type {Number}
          */
-        this.type = libConstants.PERSPECTIVE_CAMERA;
+        this.type = PERSPECTIVE_CAMERA;
     }
 
     updateProjectionMatrix() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,76 +1,47 @@
 /**
  * Модуль подключает все компоненты 2gl для того, чтобы их можно было собрать в один бандл в dist
+ * или заимпортить с помощью ES6
  */
+export {default as AmbientLight} from './lights/AmbientLight';
+export {default as BasicMeshMaterial} from './materials/BasicMeshMaterial';
+export {default as Buffer} from './Buffer';
+export {default as BufferChannel} from './BufferChannel';
+export {default as Box} from './math/Box';
+export {default as CommonPlugin} from './rendererPlugins/CommonPlugin';
+export {default as ComplexMeshMaterial} from './materials/ComplexMeshMaterial';
+export {default as DirectionalLight} from './lights/DirectionalLight';
+export {default as Frustum} from './math/Frustum';
+export {default as Geometry} from './Geometry';
+export {default as Mesh} from './Mesh';
+export {default as libConstants} from './libConstants';
+export {default as Line3} from './math/Line3';
+export {default as MultiSprite} from './MultiSprite';
+export {default as MultiSpriteMaterial} from './materials/MultiSpriteMaterial';
+export {default as MultiSpritePlugin} from './rendererPlugins/MultiSpritePlugin';
+export {default as Object3D} from './Object3D';
+export {default as Object3DPlugin} from './rendererPlugins/Object3DPlugin';
+export {default as OrthographicCamera} from './cameras/OrthographicCamera';
+export {default as PerspectiveCamera} from './cameras/PerspectiveCamera';
+export {default as Plane} from './math/Plane';
+export {default as Renderer} from './Renderer';
+export {default as RendererPlugin} from './RendererPlugin';
+export {default as Scene} from './Scene';
+export {default as Shader} from './Shader';
+export {default as ShaderProgram} from './ShaderProgram';
+export {default as Sprite} from './Sprite';
+export {default as SpriteMaterial} from './materials/SpriteMaterial';
+export {default as SpritePlugin} from './rendererPlugins/SpritePlugin';
+export {default as Texture} from './Texture';
+export {default as Ray} from './math/Ray';
+export {default as Raycaster} from './Raycaster';
+export {default as RenderTarget} from './RenderTarget';
+export {default as TransparentPlugin} from './rendererPlugins/TransparentPlugin';
+export {vec3, mat3, vec2, mat4, quat, glMatrix} from 'gl-matrix';
 
-import Renderer from './Renderer';
-import RendererPlugin from './RendererPlugin';
-import Object3D from './Object3D';
-import PerspectiveCamera from './cameras/PerspectiveCamera';
-import OrthographicCamera from './cameras/OrthographicCamera';
-import Buffer from './Buffer';
-import BufferChannel from './BufferChannel';
-import Geometry from './Geometry';
-import Shader from './Shader';
-import ShaderProgram from './ShaderProgram';
-import BasicMeshMaterial from './materials/BasicMeshMaterial';
-import ComplexMeshMaterial from './materials/ComplexMeshMaterial';
-import SpriteMaterial from './materials/SpriteMaterial';
-import MultiSpriteMaterial from './materials/MultiSpriteMaterial';
-import Mesh from './Mesh';
-import Sprite from './Sprite';
-import MultiSprite from './MultiSprite';
-import Scene from './Scene';
-import Texture from './Texture';
-import AmbientLight from './lights/AmbientLight';
-import DirectionalLight from './lights/DirectionalLight';
-import Raycaster from './Raycaster';
-import RenderTarget from './RenderTarget';
-import Ray from './math/Ray';
-import Plane from './math/Plane';
-import Box from './math/Box';
-import Frustum from './math/Frustum';
-import * as math from './math/Math';
-import Line3 from './math/Line3';
-import {vec3, mat3, vec2, mat4, quat, glMatrix} from 'gl-matrix';
+import * as Math from './math/Math';
+export {Math};
+
+import {glMatrix} from 'gl-matrix';
 
 // with Float32Array we have errors with raycast
 glMatrix.ARRAY_TYPE = (typeof Float64Array !== 'undefined') ? Float64Array : Array;
-
-const dgl = {
-    Renderer,
-    RendererPlugin,
-    Object3D,
-    PerspectiveCamera,
-    OrthographicCamera,
-    Buffer,
-    BufferChannel,
-    Geometry,
-    Mesh,
-    Sprite,
-    MultiSprite,
-    Shader,
-    ShaderProgram,
-    BasicMeshMaterial,
-    ComplexMeshMaterial,
-    SpriteMaterial,
-    MultiSpriteMaterial,
-    Scene,
-    Texture,
-    AmbientLight,
-    DirectionalLight,
-    Raycaster,
-    RenderTarget,
-    Ray,
-    Plane,
-    Frustum,
-    Box,
-    Line3,
-    Math: math,
-    vec3,
-    mat3,
-    vec2,
-    mat4,
-    quat
-};
-
-module.exports = dgl;

--- a/src/libConstants.js
+++ b/src/libConstants.js
@@ -1,26 +1,25 @@
 /*
  * Содержит разные константы.
- * Например, ORTHOGRAPHIC_CAMERA - помогает определить тип камеры без того, чтобы реквайрить весь модуль.
+ * Например; ORTHOGRAPHIC_CAMERA - помогает определить тип камеры без того; чтобы реквайрить весь модуль.
  */
-export default {
-    ORTHOGRAPHIC_CAMERA: 1,
-    PERSPECTIVE_CAMERA: 2,
+export const ORTHOGRAPHIC_CAMERA = 1;
+export const PERSPECTIVE_CAMERA = 2;
 
-    AMBIENT_LIGHT: 3,
-    DIRECTIONAL_LIGHT: 4,
+export const AMBIENT_LIGHT = 3;
+export const DIRECTIONAL_LIGHT = 4;
 
-    BASIC_MESH_MATERIAL: 5,
-    COMPLEX_MESH_MATERIAL: 6,
-    SPRITE_MATERIAL: 7,
-    MULTI_SPRITE_MATERIAL: 8,
+export const BASIC_MESH_MATERIAL = 5;
+export const COMPLEX_MESH_MATERIAL = 6;
+export const SPRITE_MATERIAL = 7;
+export const MULTI_SPRITE_MATERIAL = 8;
 
-    MESH: 9,
-    SPRITE: 10,
-    MULTI_SPRITE: 11,
-    OBJECT_3D: 12,
+export const MESH = 9;
+export const SPRITE = 10;
+export const MULTI_SPRITE = 11;
+export const OBJECT_3D = 12;
 
-    COMMON_RENDERER: 13,
-    TRANSPARENT_RENDERER: 14,
-    SPRITE_RENDERER: 15,
-    MULTI_SPRITE_RENDERER: 16
-};
+export const COMMON_RENDERER = 13;
+export const TRANSPARENT_RENDERER = 14;
+export const SPRITE_RENDERER = 15;
+export const MULTI_SPRITE_RENDERER = 16;
+export const OBJECT_3D_RENDERER = 17;

--- a/src/lights/AmbientLight.js
+++ b/src/lights/AmbientLight.js
@@ -1,4 +1,4 @@
-import libConstants from '../libConstants';
+import {AMBIENT_LIGHT} from '../libConstants';
 import Light from './Light';
 
 /**
@@ -14,7 +14,7 @@ class AmbientLight extends Light {
          * Используется для обозначения типа света
          * @type {Number}
          */
-        this.type = libConstants.AMBIENT_LIGHT;
+        this.type = AMBIENT_LIGHT;
     }
 }
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -1,4 +1,4 @@
-import libConstants from '../libConstants';
+import {DIRECTIONAL_LIGHT} from '../libConstants';
 import Light from './Light';
 
 /**
@@ -15,7 +15,7 @@ class DirectionalLight extends Light {
          * Используется для обозначения типа света
          * @type {Number}
          */
-        this.type = libConstants.DIRECTIONAL_LIGHT;
+        this.type = DIRECTIONAL_LIGHT;
     }
 }
 

--- a/src/materials/BasicMeshMaterial.js
+++ b/src/materials/BasicMeshMaterial.js
@@ -1,7 +1,7 @@
 import fragmentShader from '../shaders/basic.frag.glsl.js';
 import vertexShader from '../shaders/basic.vert.glsl.js';
 import Material from './Material';
-import libConstants from '../libConstants';
+import {BASIC_MESH_MATERIAL} from '../libConstants';
 
 const shader = {
     fragment: fragmentShader,
@@ -11,6 +11,7 @@ const shader = {
 /**
  * Простой материал для {@link Mesh}. Раскрашивает весь объект в один заданный цвет.
  * {@link Geometry} меша использующего этот материал должна содержать буфер вершин.
+ * Этот материал требует подключения {@link CommonPlugin} и {@link TransparentPlugin} к рендереру.
  *
  * @extends Material
  */
@@ -38,7 +39,7 @@ class BasicMeshMaterial extends Material {
          * Используется для обозначения типа материала
          * @type {Number}
          */
-        this.type = libConstants.BASIC_MESH_MATERIAL;
+        this.type = BASIC_MESH_MATERIAL;
     }
 
     _shaderProgramBind({gl, object, camera}) {

--- a/src/materials/ComplexMeshMaterial.js
+++ b/src/materials/ComplexMeshMaterial.js
@@ -2,7 +2,7 @@ import fragmentShader from '../shaders/complex.frag.glsl.js';
 import vertexShader from '../shaders/complex.vert.glsl.js';
 import {vec3, mat3} from 'gl-matrix';
 import Material from './Material';
-import libConstants from '../libConstants';
+import {COMPLEX_MESH_MATERIAL, DIRECTIONAL_LIGHT, AMBIENT_LIGHT} from '../libConstants';
 
 const shader = {
     fragment: fragmentShader,
@@ -21,6 +21,8 @@ const shader = {
  * 5. texture - 2х мерные координаты сопоставляющие координаты грани к координатам текстуры
  * 6. textureEnable - будет ли использоваться текстура для данной вершины,
  * принимает два значаения: 0 - нет, 1 - да
+ *
+ * Этот материал требует подключения {@link CommonPlugin} и {@link TransparentPlugin} к рендереру.
  *
  * @extends Material
  */
@@ -43,7 +45,7 @@ class ComplexMeshMaterial extends Material {
          * Используется для обозначения типа материала
          * @type {Number}
          */
-        this.type = libConstants.COMPLEX_MESH_MATERIAL;
+        this.type = COMPLEX_MESH_MATERIAL;
     }
 
     /**
@@ -78,7 +80,7 @@ class ComplexMeshMaterial extends Material {
         let directionLightNumber = 0;
 
         scene.getLights().forEach(l => {
-            if (l.type === libConstants.DIRECTIONAL_LIGHT) {
+            if (l.type === DIRECTIONAL_LIGHT) {
                 directionLightNumber++;
             }
         });
@@ -117,9 +119,9 @@ class ComplexMeshMaterial extends Material {
             let directionLightsPosition = [];
 
             lights.forEach(light => {
-                if (light.type === libConstants.AMBIENT_LIGHT) {
+                if (light.type === AMBIENT_LIGHT) {
                     uniforms.uAmbientLightColor = light.color;
-                } else if (light.type === libConstants.DIRECTIONAL_LIGHT) {
+                } else if (light.type === DIRECTIONAL_LIGHT) {
                     directionLightsColor = directionLightsColor.concat(light.color);
 
                     const reverted = vec3.create();

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,10 +1,7 @@
 import definitions from './definitions';
 import ShaderProgram from '../ShaderProgram';
-import libConstants from '../libConstants';
+import {COMMON_RENDERER, TRANSPARENT_RENDERER} from '../libConstants';
 import Shader from '../Shader';
-
-import '../rendererPlugins/CommonPlugin';
-import '../rendererPlugins/TransparentPlugin';
 
 const cachedPrograms = {};
 
@@ -79,9 +76,9 @@ class Material {
      */
     typifyForRender(renderPlugins, object) {
         if (this.opacity === 1) {
-            renderPlugins[libConstants.COMMON_RENDERER].addObject(object);
+            renderPlugins[COMMON_RENDERER].addObject(object);
         } else {
-            renderPlugins[libConstants.TRANSPARENT_RENDERER].addObject(object);
+            renderPlugins[TRANSPARENT_RENDERER].addObject(object);
         }
     }
 

--- a/src/materials/MultiSpriteMaterial.js
+++ b/src/materials/MultiSpriteMaterial.js
@@ -1,4 +1,4 @@
-import libConstants from '../libConstants';
+import {MULTI_SPRITE_MATERIAL} from '../libConstants';
 
 /**
  * Материал для мультиспрайтов. Она не наследуются от {@link Material}
@@ -14,7 +14,7 @@ class MultiSpriteMaterial {
          * Используется для обозначения типа материала
          * @type {Number}
          */
-        this.type = libConstants.MULTI_SPRITE_MATERIAL;
+        this.type = MULTI_SPRITE_MATERIAL;
     }
 
     /**

--- a/src/materials/SpriteMaterial.js
+++ b/src/materials/SpriteMaterial.js
@@ -1,4 +1,4 @@
-import libConstants from '../libConstants';
+import {SPRITE_MATERIAL} from '../libConstants';
 
 /**
  * Материал для спрайтов. Она не наследуются от {@link Material}
@@ -15,7 +15,7 @@ class SpriteMaterial {
          * Используется для обозначения типа материала
          * @type {Number}
          */
-        this.type = libConstants.SPRITE_MATERIAL;
+        this.type = SPRITE_MATERIAL;
     }
 
     /**

--- a/src/rendererPlugins/CommonPlugin.js
+++ b/src/rendererPlugins/CommonPlugin.js
@@ -1,11 +1,11 @@
 import RendererPlugin from '../RendererPlugin';
-import Renderer from '../Renderer';
-import libConstants from '../libConstants';
+import {COMMON_RENDERER} from '../libConstants';
 
 /**
  * Плагин для рендера простых объектов.
- * Для того, чтобы он добавился к рендеру, модуль нужно зареквайрить.
- * Для {@link BasicMeshMaterial} и {@link ComplexMeshMaterial} модуль подключается автоматически.
+ * Для того, чтобы он добавился к рендеру, нужно вызвать {@link Renderer#addPlugin}.
+ *
+ * @extends RendererPlugin
  */
 class CommonPlugin extends RendererPlugin {
     constructor() {
@@ -15,7 +15,7 @@ class CommonPlugin extends RendererPlugin {
          * Используется для обозначения типа плагина
          * @type {Number}
          */
-        this.type = libConstants.COMMON_RENDERER;
+        this.type = COMMON_RENDERER;
     }
 
     /**
@@ -47,7 +47,5 @@ class CommonPlugin extends RendererPlugin {
         return a.renderOrder - b.renderOrder;
     }
 }
-
-Renderer.addPlugin(0, CommonPlugin);
 
 export default CommonPlugin;

--- a/src/rendererPlugins/MultiSpritePlugin.js
+++ b/src/rendererPlugins/MultiSpritePlugin.js
@@ -2,12 +2,14 @@ import fragmentShader from '../shaders/multiSprite.frag.glsl.js';
 import vertexShader from '../shaders/multiSprite.vert.glsl.js';
 import ShaderProgram from '../ShaderProgram';
 import RendererPlugin from '../RendererPlugin';
-import Renderer from '../Renderer';
 import Shader from '../Shader';
-import libConstants from '../libConstants';
+import {MULTI_SPRITE_RENDERER} from '../libConstants';
 
 /**
- *  Плагин для рендера {@MultiSprite} объектов, добавляется автоматически при их использовании.
+ * Плагин для рендера {@MultiSprite} объектов.
+ * Для того, чтобы он добавился к рендеру, нужно вызвать {@link Renderer#addPlugin}.
+ *
+ * @extends RendererPlugin
  */
 class MultiSpritePlugin extends RendererPlugin {
     constructor(renderer) {
@@ -34,7 +36,7 @@ class MultiSpritePlugin extends RendererPlugin {
             ]
         });
 
-        this.type = libConstants.MULTI_SPRITE_RENDERER;
+        this.type = MULTI_SPRITE_RENDERER;
     }
 
     /**
@@ -71,7 +73,5 @@ class MultiSpritePlugin extends RendererPlugin {
         return this;
     }
 }
-
-Renderer.addPlugin(30, MultiSpritePlugin);
 
 export default MultiSpritePlugin;

--- a/src/rendererPlugins/Object3DPlugin.js
+++ b/src/rendererPlugins/Object3DPlugin.js
@@ -1,0 +1,32 @@
+import RendererPlugin from '../RendererPlugin';
+import {OBJECT_3D_RENDERER} from '../libConstants';
+
+/**
+ * Плагин - заглушка для {@link Object3D}.
+ * Он не делает ничего лишнего, только вызывает метод {@link Object3D#render}.
+ * Этот плагин должен всегда рендериться первым и добавляется автоматически.
+ */
+class Object3DPlugin extends RendererPlugin {
+    constructor() {
+        super();
+
+        /**
+         * Используется для обозначения типа плагина
+         * @type {Number}
+         */
+        this.type = OBJECT_3D_RENDERER;
+    }
+
+    /**
+     * Вызывает {@link Object3D#render}
+     * @param {State} state
+     */
+    render(state) {
+        this._objects.forEach(object => object.render(state));
+        this._objects = [];
+
+        return this;
+    }
+}
+
+export default Object3DPlugin;

--- a/src/rendererPlugins/SpritePlugin.js
+++ b/src/rendererPlugins/SpritePlugin.js
@@ -3,13 +3,15 @@ import vertexShader from '../shaders/sprite.vert.glsl.js';
 import ShaderProgram from '../ShaderProgram';
 import RendererPlugin from '../RendererPlugin';
 import Geometry from '../Geometry';
-import Renderer from '../Renderer';
 import Shader from '../Shader';
 import Buffer from '../Buffer';
-import libConstants from '../libConstants';
+import {SPRITE_RENDERER} from '../libConstants';
 
 /**
- *  Плагин для рендера {@Sprite} объектов, добавляется автоматически при их использовании.
+ * Плагин для рендера {@Sprite} объектов.
+ * Для того, чтобы он добавился к рендеру, нужно вызвать {@link Renderer#addPlugin}.
+ *
+ * @extends RendererPlugin
  */
 class SpritePlugin extends RendererPlugin {
     constructor() {
@@ -56,7 +58,7 @@ class SpritePlugin extends RendererPlugin {
             ]
         });
 
-        this.type = libConstants.SPRITE_RENDERER;
+        this.type = SPRITE_RENDERER;
     }
 
     /**
@@ -95,7 +97,5 @@ class SpritePlugin extends RendererPlugin {
         return this;
     }
 }
-
-Renderer.addPlugin(20, SpritePlugin);
 
 export default SpritePlugin;

--- a/src/rendererPlugins/TransparentPlugin.js
+++ b/src/rendererPlugins/TransparentPlugin.js
@@ -1,17 +1,17 @@
 import RendererPlugin from '../RendererPlugin';
-import Renderer from '../Renderer';
-import libConstants from '../libConstants';
+import {TRANSPARENT_RENDERER} from '../libConstants';
 
 /**
  * Плагин для рендера прозрачных объектов.
- * Для того, чтобы он добавился к рендеру, модуль нужно зареквайрить.
- * Для {@link BasicMeshMaterial} и {@link ComplexMeshMaterial} модуль подключается автоматически.
+ * Для того, чтобы он добавился к рендеру, нужно вызвать {@link Renderer#addPlugin}.
+ *
+ * @extends RendererPlugin
  */
 class TransparentPlugin extends RendererPlugin {
     constructor() {
         super();
 
-        this.type = libConstants.TRANSPARENT_RENDERER;
+        this.type = TRANSPARENT_RENDERER;
     }
 
     /**
@@ -55,7 +55,5 @@ class TransparentPlugin extends RendererPlugin {
         return bZ - aZ;
     }
 }
-
-Renderer.addPlugin(10, TransparentPlugin);
 
 export default TransparentPlugin;

--- a/test/Mesh.spec.js
+++ b/test/Mesh.spec.js
@@ -6,8 +6,10 @@ import Geometry from '../src/Geometry';
 import Buffer from '../src/Buffer';
 import BasicMeshMaterial from '../src/materials/BasicMeshMaterial';
 import Object3D from '../src/Object3D';
-import libConstants from '../src/libConstants';
+import {MESH} from '../src/libConstants';
 import Renderer from '../src/Renderer';
+import CommonPlugin from '../src/rendererPlugins/CommonPlugin';
+import TransparentPlugin from '../src/rendererPlugins/TransparentPlugin';
 
 import Mesh from '../src/Mesh';
 
@@ -41,7 +43,7 @@ describe('Mesh', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.MESH, mesh.type);
+            assert.equal(MESH, mesh.type);
         });
     });
 
@@ -108,6 +110,9 @@ describe('Mesh', () => {
         beforeEach(() => {
             spy = sinon.spy(material, 'typifyForRender');
             renderer = new Renderer();
+            renderer
+                .addPlugin(CommonPlugin)
+                .addPlugin(TransparentPlugin);
         });
 
         afterEach(() => {

--- a/test/MultiSprite.spec.js
+++ b/test/MultiSprite.spec.js
@@ -6,7 +6,7 @@ import MultiSpriteMaterial from '../src/materials/MultiSpriteMaterial';
 import ShaderProgram from '../src/ShaderProgram';
 import Object3D from '../src/Object3D';
 import Texture from '../src/Texture';
-import libConstants from '../src/libConstants';
+import {MULTI_SPRITE} from '../src/libConstants';
 
 import MultiSprite from '../src/MultiSprite';
 
@@ -45,7 +45,7 @@ describe('MultiSprite', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.MULTI_SPRITE, multiSprite.type);
+            assert.equal(MULTI_SPRITE, multiSprite.type);
         });
     });
 

--- a/test/Renderer.spec.js
+++ b/test/Renderer.spec.js
@@ -6,7 +6,6 @@ import sinon from 'sinon';
 import Scene from '../src/Scene';
 import Camera from '../src/cameras/Camera';
 import RenderTarget from '../src/RenderTarget';
-import RendererPlugin from '../src/RendererPlugin';
 
 import Renderer from '../src/Renderer';
 
@@ -295,31 +294,6 @@ describe('Renderer', () => {
             renderer.render(scene, camera);
 
             assert.ok(spy.calledOnce);
-        });
-    });
-
-    describe('#addPlugin', () => {
-        it('should add and sort new plugins', () => {
-            class PluginA extends RendererPlugin {
-                constructor() {
-                    super();
-                    this.type = 100001;
-                }
-            }
-
-            class PluginB extends RendererPlugin {
-                constructor() {
-                    super();
-                    this.type = 100002;
-                }
-            }
-
-            Renderer.addPlugin(4000, PluginA);
-            Renderer.addPlugin(3000, PluginB);
-
-            const length = Renderer.plugins.length;
-            assert.equal(Renderer.plugins[length - 1].Plugin, PluginA);
-            assert.equal(Renderer.plugins[length - 2].Plugin, PluginB);
         });
     });
 });

--- a/test/Sprite.spec.js
+++ b/test/Sprite.spec.js
@@ -6,7 +6,7 @@ import SpriteMaterial from '../src/materials/SpriteMaterial';
 import ShaderProgram from '../src/ShaderProgram';
 import Object3D from '../src/Object3D';
 import Texture from '../src/Texture';
-import libConstants from '../src/libConstants';
+import {SPRITE} from '../src/libConstants';
 
 import Sprite from '../src/Sprite';
 
@@ -33,7 +33,7 @@ describe('Sprite', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.SPRITE, sprite.type);
+            assert.equal(SPRITE, sprite.type);
         });
     });
 

--- a/test/cameras/OrthographicCamera.spec.js
+++ b/test/cameras/OrthographicCamera.spec.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import {slice, round} from '../utils';
 
 import Camera from '../../src/cameras/Camera';
-import libConstants from '../../src/libConstants';
+import {ORTHOGRAPHIC_CAMERA} from '../../src/libConstants';
 
 import OrthographicCamera from '../../src/cameras/OrthographicCamera';
 
@@ -34,7 +34,7 @@ describe('OrthographicCamera', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.ORTHOGRAPHIC_CAMERA, camera.type);
+            assert.equal(ORTHOGRAPHIC_CAMERA, camera.type);
         });
     });
 

--- a/test/cameras/PerspectiveCamera.spec.js
+++ b/test/cameras/PerspectiveCamera.spec.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import {slice} from '../utils';
 
 import Camera from '../../src/cameras/Camera';
-import libConstants from '../../src/libConstants';
+import {PERSPECTIVE_CAMERA} from '../../src/libConstants';
 
 import PerspectiveCamera from '../../src/cameras/PerspectiveCamera';
 
@@ -30,7 +30,7 @@ describe('PerspectiveCamera', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.PERSPECTIVE_CAMERA, camera.type);
+            assert.equal(PERSPECTIVE_CAMERA, camera.type);
         });
     });
 

--- a/test/lights/AmbientLight.spec.js
+++ b/test/lights/AmbientLight.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import libConstants from '../../src/libConstants';
+import {AMBIENT_LIGHT} from '../../src/libConstants';
 import Light from '../../src/lights/Light';
 import AmbientLight from '../../src/lights/AmbientLight';
 
@@ -20,7 +20,7 @@ describe('AmbientLight', () => {
         it('should have right type', () => {
             const color = [0.1, 0.5, 0.7];
             const light = new AmbientLight(color);
-            assert.equal(libConstants.AMBIENT_LIGHT, light.type);
+            assert.equal(AMBIENT_LIGHT, light.type);
         });
     });
 });

--- a/test/lights/DirectionalLight.spec.js
+++ b/test/lights/DirectionalLight.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import libConstants from '../../src/libConstants';
+import {DIRECTIONAL_LIGHT} from '../../src/libConstants';
 import Light from '../../src/lights/Light';
 import DirectionalLight from '../../src/lights/DirectionalLight';
 
@@ -20,7 +20,7 @@ describe('AmbientLight', () => {
         it('should have right type', () => {
             const color = [0.1, 0.5, 0.7];
             const light = new DirectionalLight(color);
-            assert.equal(libConstants.DIRECTIONAL_LIGHT, light.type);
+            assert.equal(DIRECTIONAL_LIGHT, light.type);
         });
     });
 });

--- a/test/materials/BasicMeshMaterial.spec.js
+++ b/test/materials/BasicMeshMaterial.spec.js
@@ -4,7 +4,7 @@ import Mesh from '../../src/Mesh';
 import Material from '../../src/materials/Material';
 import Geometry from '../../src/Geometry';
 import Buffer from '../../src/Buffer';
-import libConstants from '../../src/libConstants';
+import {BASIC_MESH_MATERIAL} from '../../src/libConstants';
 
 import BasicMeshMaterial from '../../src/materials/BasicMeshMaterial';
 
@@ -37,7 +37,7 @@ describe('BasicMeshMaterial', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.BASIC_MESH_MATERIAL, material.type);
+            assert.equal(BASIC_MESH_MATERIAL, material.type);
         });
     });
 

--- a/test/materials/ComplexMeshMaterial.spec.js
+++ b/test/materials/ComplexMeshMaterial.spec.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import Material from '../../src/materials/Material';
-import libConstants from '../../src/libConstants';
+import {COMPLEX_MESH_MATERIAL} from '../../src/libConstants';
 
 import ComplexMeshMaterial from '../../src/materials/ComplexMeshMaterial';
 
@@ -21,7 +21,7 @@ describe('ComplexMeshMaterial', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.COMPLEX_MESH_MATERIAL, material.type);
+            assert.equal(COMPLEX_MESH_MATERIAL, material.type);
         });
     });
 

--- a/test/materials/Material.spec.js
+++ b/test/materials/Material.spec.js
@@ -1,9 +1,11 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import {getRenderState} from '../utils';
-import Object3D from '../../src/Object3D';
+import Mesh from '../../src/Mesh';
 import Renderer from '../../src/Renderer';
-import libConstants from '../../src/libConstants';
+import {COMMON_RENDERER, TRANSPARENT_RENDERER} from '../../src/libConstants';
+import CommonPlugin from '../../src/rendererPlugins/CommonPlugin';
+import TransparentPlugin from '../../src/rendererPlugins/TransparentPlugin';
 
 import Material from '../../src/materials/Material';
 
@@ -38,26 +40,29 @@ describe('Material', () => {
     });
 
     describe('#typifyForRender', () => {
-        let object, renderer;
+        let mesh, renderer;
 
         beforeEach(() => {
-            object = new Object3D();
+            mesh = new Mesh();
             renderer = new Renderer();
+            renderer
+                .addPlugin(CommonPlugin)
+                .addPlugin(TransparentPlugin);
         });
 
         it('should identify as common', () => {
-            const spy1 = sinon.spy(renderer._pluginsByType[libConstants.COMMON_RENDERER], 'addObject');
-            const spy2 = sinon.spy(renderer._pluginsByType[libConstants.TRANSPARENT_RENDERER], 'addObject');
-            material.typifyForRender(renderer._pluginsByType, object);
+            const spy1 = sinon.spy(renderer._pluginsByType[COMMON_RENDERER], 'addObject');
+            const spy2 = sinon.spy(renderer._pluginsByType[TRANSPARENT_RENDERER], 'addObject');
+            material.typifyForRender(renderer._pluginsByType, mesh);
             assert.ok(spy1.called);
             assert.ok(!spy2.called);
         });
 
         it('should identify as transparent', () => {
-            const spy1 = sinon.spy(renderer._pluginsByType[libConstants.COMMON_RENDERER], 'addObject');
-            const spy2 = sinon.spy(renderer._pluginsByType[libConstants.TRANSPARENT_RENDERER], 'addObject');
+            const spy1 = sinon.spy(renderer._pluginsByType[COMMON_RENDERER], 'addObject');
+            const spy2 = sinon.spy(renderer._pluginsByType[TRANSPARENT_RENDERER], 'addObject');
             material.opacity = 0.5;
-            material.typifyForRender(renderer._pluginsByType, object);
+            material.typifyForRender(renderer._pluginsByType, mesh);
             assert.ok(!spy1.called);
             assert.ok(spy2.called);
         });

--- a/test/materials/MultiSpriteMaterial.spec.js
+++ b/test/materials/MultiSpriteMaterial.spec.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import Material from '../../src/materials/Material';
-import libConstants from '../../src/libConstants';
+import {MULTI_SPRITE_MATERIAL} from '../../src/libConstants';
 
 import MultiSpriteMaterial from '../../src/materials/MultiSpriteMaterial';
 
@@ -21,7 +21,7 @@ describe('MultiSpriteMaterial', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.MULTI_SPRITE_MATERIAL, material.type);
+            assert.equal(MULTI_SPRITE_MATERIAL, material.type);
         });
     });
 

--- a/test/materials/SpriteMaterial.spec.js
+++ b/test/materials/SpriteMaterial.spec.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import Material from '../../src/materials/Material';
-import libConstants from '../../src/libConstants';
+import {SPRITE_MATERIAL} from '../../src/libConstants';
 
 import SpriteMaterial from '../../src/materials/SpriteMaterial';
 
@@ -25,7 +25,7 @@ describe('SpriteMaterial', () => {
         });
 
         it('should have right type', () => {
-            assert.equal(libConstants.SPRITE_MATERIAL, material.type);
+            assert.equal(SPRITE_MATERIAL, material.type);
         });
     });
 

--- a/test/math/Plane.spec.js
+++ b/test/math/Plane.spec.js
@@ -96,6 +96,6 @@ describe('Plane', () => {
             assert.deepEqual(plane.normal, [5, 0, 0]);
             plane.normalize();
             assert.deepEqual(plane.normal, [1, 0, 0]);
-        })
+        });
     });
 });


### PR DESCRIPTION
* Теперь библиотеку можно собирать с помощью tree-shaking, и все лишнии компоненты будут удаляться из бандла
* В npm теперь, кроме сборки для ES5, ещё добавляется ES6 код в папке `src`
* Константы в `libConstants` теперь экспортяться по отдельности
* Раньше при подключении модуля `Material`, внутри неявно подключились плагины к рендереру `CommonPlugin` и `TransparentPlugin`. Это было неплохо и пользователям либы не приходилось делать дополнительных движений, но это ломало весь tree-shaking. Теперь нужно явно добавлять плагины к рендереру, например:
```js
renderer
  .addPlugin(dgl.CommonPlugin)
  .addPlugin(dgl.TransparentPlugin);
```
* Добавил `Object3DPlugin` - заглушку для объектов класса `Object3D`, который ничего не делает, но вызывается самым первым и дёргает метод render у попавших в него объектов. Это полезно, когда вложенные объекты в `Object3D` должны использовать информацию из родителя, которая обновляется перед рендерингом.