### PR TITLE
Remove shader checks in production

### DIFF
--- a/src/Shader.js
+++ b/src/Shader.js
@@ -63,7 +63,7 @@ class Shader {
         gl.shaderSource(shader, this._code);
         gl.compileShader(shader);
 
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        if (process.env.NODE_ENV !== 'production' && !gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
             console.log(gl.getShaderInfoLog(shader));
         }
     }

--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -102,7 +102,7 @@ class ShaderProgram {
 
         gl.linkProgram(this._webglProgram);
 
-        if (!gl.getProgramParameter(this._webglProgram, gl.LINK_STATUS)) {
+        if (process.env.NODE_ENV !== 'production' && !gl.getProgramParameter(this._webglProgram, gl.LINK_STATUS)) {
             console.log('Could not initialize shaders');
             this._status = ShaderProgram.FAILED;
             return;


### PR DESCRIPTION
`getShaderParameter` в некоторых случаях могут вызывать подлагивания, а с другой стороны эти проверки очень полезны при разработки. Поэтому добавил возможность их отключать в продакшен сборке. Проект использующий `2gl` может через `envify` прокинуть переменную `NODE_ENV=production`.