### PR TITLE
Split Buffer to GeometryBuffer

### DIFF
--- a/examples/basicMeshPerformance.html
+++ b/examples/basicMeshPerformance.html
@@ -79,7 +79,7 @@
 
         var geometry = new dgl.Geometry();
 
-        var vertexBuffer = new dgl.Buffer(new Float32Array(vertices), 3);
+        var vertexBuffer = new dgl.GeometryBuffer(new Float32Array(vertices), 3);
 
         geometry.setBuffer('position', vertexBuffer);
 

--- a/examples/complexMeshPerformance.html
+++ b/examples/complexMeshPerformance.html
@@ -86,8 +86,8 @@
         var material = new dgl.ComplexMeshMaterial();
         var geometry = new dgl.Geometry();
 
-        var vertexBuffer = new dgl.Buffer(new Float32Array(vertices), 3);
-        var colorBuffer = new dgl.Buffer(new Float32Array(colors), 3);
+        var vertexBuffer = new dgl.GeometryBuffer(new Float32Array(vertices));
+        var colorBuffer = new dgl.GeometryBuffer(new Float32Array(colors));
 
         var uv = [];
         var textureEnable = [];
@@ -97,9 +97,9 @@
             textureEnable.push(l % 2, l % 2, l % 2);
             l++;
         }
-        var uvBuffer = new dgl.Buffer(new Float32Array(uv), 2);
-        var textureEnableBuffer = new dgl.Buffer(new Float32Array(textureEnable), 1);
-        var emissiveBuffer = new dgl.Buffer(new Float32Array(vertices.length ), 3);
+        var uvBuffer = new dgl.GeometryBuffer(new Float32Array(uv), {itemSize: 2});
+        var textureEnableBuffer = new dgl.GeometryBuffer(new Float32Array(textureEnable), {itemSize: 1});
+        var emissiveBuffer = new dgl.GeometryBuffer(new Float32Array(vertices.length));
 
         geometry
                 .setBuffer('position', vertexBuffer)

--- a/examples/debug/spriteTextureBorder.html
+++ b/examples/debug/spriteTextureBorder.html
@@ -27,7 +27,9 @@
             canvas: 'canvas'
         });
 
-        renderer.setSize(300, 300);
+        renderer
+            .addPlugin(new dgl.SpritePlugin())
+            .setSize(300, 300);
         renderer.clearColor = [0.94, 0.94, 0.94, 1];
 
         var spriteMaterial = new dgl.SpriteMaterial();

--- a/src/BufferChannel.js
+++ b/src/BufferChannel.js
@@ -1,13 +1,5 @@
 import Buffer from './Buffer';
 
-const defaultOptions = {
-    itemSize: 3,
-    dataType: Buffer.Float,
-    stride: 0,
-    offset: 0,
-    normalized: false
-};
-
 /**
  * Класс BufferChannel используется, если данные в обычном буфере имееют разные типы
  * и предназначены для разных атрибутов шейдера, т.е. нужно использовать webgl параметры stride и offset.
@@ -31,7 +23,7 @@ class BufferChannel {
          * @type {BufferBindOptions}
          * @ignore
          */
-        this._options = Object.assign({}, defaultOptions, options);
+        this.options = Object.assign({}, Buffer.defaultOptions, options);
     }
 
     /**
@@ -39,7 +31,7 @@ class BufferChannel {
      * Вызывает {@link Buffer#bind} исходного буфера.
      */
     bind(gl, location) {
-        this._buffer.bind(gl, location, this._options);
+        this._buffer.bind(gl, location, this.options);
     }
 }
 

--- a/src/Geometry.js
+++ b/src/Geometry.js
@@ -1,15 +1,15 @@
 import {vec3} from 'gl-matrix';
-import Buffer from './Buffer';
+import GeometryBuffer from './GeometryBuffer';
 import Box from './math/Box';
 
 /**
  * Используется для задания геометрий объектов.
- * В качестве данных используются {@link Buffer}.
+ * В качестве данных используются {@link GeometryBuffer}.
  */
 class Geometry {
     constructor() {
         /**
-         * Словарь вида: название буфера - Buffer
+         * Словарь вида: название буфера - GeometryBuffer
          * @type {Object}
          */
         this.buffers = {};
@@ -25,7 +25,7 @@ class Geometry {
     /**
      * Сохраняет буфер в геометрию
      * @param {String} name Название буфера
-     * @param {Buffer} buffer
+     * @param {GeometryBuffer} buffer
      */
     setBuffer(name, buffer) {
         this.buffers[name] = buffer;
@@ -36,7 +36,7 @@ class Geometry {
     /**
      * Возвращает буфер из геометрии
      * @param {String} name Название буфера
-     * @returns {Buffer}
+     * @returns {GeometryBuffer}
      */
     getBuffer(name) {
         return this.buffers[name];
@@ -50,7 +50,7 @@ class Geometry {
 
         if (!positionBuffer) { return this; }
 
-        const normals = new Float32Array(positionBuffer.length * positionBuffer.itemSize);
+        const normals = new Float32Array(positionBuffer.length * positionBuffer.options.itemSize);
 
         const ab = vec3.create();
         const cb = vec3.create();
@@ -69,7 +69,7 @@ class Geometry {
             normals.set(n, (i + 2) * 3);
         }
 
-        this.setBuffer('normal', new Buffer(normals, 3));
+        this.setBuffer('normal', new GeometryBuffer(normals, {itemSize: 3}));
 
         return this;
     }

--- a/src/GeometryBuffer.js
+++ b/src/GeometryBuffer.js
@@ -1,0 +1,72 @@
+import Buffer from './Buffer';
+
+/**
+ * Используется для хранения и подготовки данных для передачи в атрибуты шейдера.
+ * В отличие от {@link Buffer}, принимает в качестве аргумента типизированный массив.
+ * Это позволяет работать с данными в {@link Geometry}, например, вычислять BoundingBox.
+ *
+ * @param {TypedArray} array Типизированный массив данных, например, координат вершин
+ * @param {?BufferBindOptions} options Параметры передачи буфера в видеокарту
+ */
+export default class GeometryBuffer extends Buffer {
+    constructor(array, options) {
+        super(array, options);
+
+        this._array = array;
+
+        /**
+         * Количество элементов в массиве данных
+         * @type {Number}
+         */
+        this.length = array.length / this.options.itemSize;
+    }
+
+    /**
+     * Возвращает массив данных
+     * @returns {TypedArray}
+     */
+    getArray() {
+        return this._array;
+    }
+
+    /**
+     * Возвращает элемент из массива данных
+     * @param {Number} index Номер элемента в массиве данных
+     * @returns {TypedArray}
+     */
+    getElement(index) {
+        return this._array.subarray(index * this.options.itemSize, (index + 1) * this.options.itemSize);
+    }
+
+    /**
+     * Возвращает тройку элементов из массива данных
+     * @param {Number} index Индекс
+     * @returns {TypedArray[]}
+     */
+    getTriangle(index) {
+        index *= 3;
+
+        return [
+            this.getElement(index),
+            this.getElement(index + 1),
+            this.getElement(index + 2)
+        ];
+    }
+
+    /**
+     * Конкатенирует данный буфер с другим.
+     * Осторожно, метод не проверяет одинаковой размерности данные или нет.
+     * @param {GeometryBuffer} buffer
+     */
+    concat(buffer) {
+        const addArray = buffer.getArray();
+        const newArray = new this._array.constructor(this._array.length + addArray.length);
+        newArray.set(this._array, 0);
+        newArray.set(addArray, this._array.length);
+
+        this._array = newArray;
+        this.length = newArray.length / this.options.itemSize;
+
+        return this;
+    }
+}

--- a/src/MultiSprite.js
+++ b/src/MultiSprite.js
@@ -1,6 +1,6 @@
 import Object3D from './Object3D';
 import Geometry from './Geometry';
-import Buffer from './Buffer';
+import GeometryBuffer from './GeometryBuffer';
 import {MULTI_SPRITE, MULTI_SPRITE_RENDERER} from './libConstants';
 
 /**
@@ -259,22 +259,22 @@ class MultiSprite extends Object3D {
     _initGeometry() {
         this._geometry = new Geometry();
 
-        const textureBuffer = new Buffer(this._data.texture.array, 2);
-        textureBuffer.drawType = Buffer.DynamicDraw;
+        const textureBuffer = new GeometryBuffer(this._data.texture.array, {itemSize: 2});
+        textureBuffer.drawType = GeometryBuffer.DynamicDraw;
 
-        const positionBuffer = new Buffer(this._data.position.array, 3);
-        positionBuffer.drawType = Buffer.DynamicDraw;
+        const positionBuffer = new GeometryBuffer(this._data.position.array, {itemSize: 3});
+        positionBuffer.drawType = GeometryBuffer.DynamicDraw;
 
-        const scaleBuffer = new Buffer(this._data.scale.array, 2);
-        scaleBuffer.drawType = Buffer.DynamicDraw;
+        const scaleBuffer = new GeometryBuffer(this._data.scale.array, {itemSize: 2});
+        scaleBuffer.drawType = GeometryBuffer.DynamicDraw;
 
-        const offsetBuffer = new Buffer(this._data.offset.array, 2);
-        offsetBuffer.drawType = Buffer.DynamicDraw;
+        const offsetBuffer = new GeometryBuffer(this._data.offset.array, {itemSize: 2});
+        offsetBuffer.drawType = GeometryBuffer.DynamicDraw;
 
-        const colorAlphaBuffer = new Buffer(this._data.colorAlpha.array, 1);
-        colorAlphaBuffer.drawType = Buffer.DynamicDraw;
+        const colorAlphaBuffer = new GeometryBuffer(this._data.colorAlpha.array, {itemSize: 1});
+        colorAlphaBuffer.drawType = GeometryBuffer.DynamicDraw;
 
-        const dispositionBuffer = new Buffer(this._data.disposition.array, 3);
+        const dispositionBuffer = new GeometryBuffer(this._data.disposition.array, {itemSize: 3});
 
         this._geometry
             .setBuffer('disposition', dispositionBuffer)

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export {default as AmbientLight} from './lights/AmbientLight';
 export {default as BasicMeshMaterial} from './materials/BasicMeshMaterial';
 export {default as Buffer} from './Buffer';
 export {default as BufferChannel} from './BufferChannel';
+export {default as GeometryBuffer} from './GeometryBuffer';
 export {default as Box} from './math/Box';
 export {default as CommonPlugin} from './rendererPlugins/CommonPlugin';
 export {default as ComplexMeshMaterial} from './materials/ComplexMeshMaterial';

--- a/src/rendererPlugins/SpritePlugin.js
+++ b/src/rendererPlugins/SpritePlugin.js
@@ -4,7 +4,7 @@ import ShaderProgram from '../ShaderProgram';
 import RendererPlugin from '../RendererPlugin';
 import Geometry from '../Geometry';
 import Shader from '../Shader';
-import Buffer from '../Buffer';
+import GeometryBuffer from '../GeometryBuffer';
 import {SPRITE_RENDERER} from '../libConstants';
 
 /**
@@ -19,24 +19,24 @@ class SpritePlugin extends RendererPlugin {
 
         this._geometry = new Geometry();
         this._geometry
-            .setBuffer('position', new Buffer(new Float32Array([
+            .setBuffer('position', new GeometryBuffer(new Float32Array([
                 -0.5, -0.5, 0,
                 0.5, -0.5, 0,
                 0.5, 0.5, 0,
                 -0.5, 0.5, 0
-            ]), 3))
-            .setBuffer('texture', new Buffer(new Float32Array([
+            ])))
+            .setBuffer('texture', new GeometryBuffer(new Float32Array([
                 0, 0,
                 1, 0,
                 1, 1,
                 0, 1
-            ]), 2))
-            .setBuffer('index', new Buffer(new Uint16Array([
+            ]), {itemSize: 2}))
+            .setBuffer('index', new GeometryBuffer(new Uint16Array([
                 1, 2, 0,
                 3, 0, 2
-            ]), 1));
+            ]), {itemSize: 1}));
 
-        this._geometry.getBuffer('index').type = Buffer.ElementArrayBuffer;
+        this._geometry.getBuffer('index').type = GeometryBuffer.ElementArrayBuffer;
 
         this._shaderProgram = new ShaderProgram({
             vertex: new Shader('vertex', vertexShader),

--- a/test/Buffer.spec.js
+++ b/test/Buffer.spec.js
@@ -1,14 +1,14 @@
 import assert from 'assert';
-import {slice, flatten, getNewGlContext} from './utils';
+import {getNewGlContext} from './utils';
 import sinon from 'sinon';
 
 import Buffer from '../src/Buffer';
 
 describe('Buffer', () => {
-    let squareVertices, buffer;
+    let buffer;
 
     beforeEach(() => {
-        squareVertices = [
+        const squareVertices = [
             -1, 0, -1,
             1, 0, -1,
             -1, 0, 1,
@@ -17,25 +17,11 @@ describe('Buffer', () => {
             1, 0, -1
         ];
 
-        buffer = new Buffer(new Float32Array(squareVertices), 3);
+        buffer = new Buffer(new Float32Array(squareVertices));
     });
 
     afterEach(() => {
-        squareVertices = buffer = null;
-    });
-
-    describe('#constructor', () => {
-        it('should have right itemSize field', () => {
-            assert.equal(buffer.itemSize, 3);
-        });
-
-        it('should calculate right length field', () => {
-            assert.equal(buffer.length, 6);
-        });
-
-        it('should have right default field', () => {
-            assert.equal(buffer.type, Buffer.ArrayBuffer);
-        });
+        buffer = null;
     });
 
     describe('#bind', () => {
@@ -66,25 +52,6 @@ describe('Buffer', () => {
             assert.ok(!spy.called);
         });
 
-        it('should delete and init buffer if gl context changed', () => {
-            buffer.bind(gl, 1);
-
-            const newGlContext = getNewGlContext();
-            const spy = sinon.spy(newGlContext, 'createBuffer');
-
-            buffer.bind(newGlContext);
-
-            assert.ok(spy.calledOnce);
-        });
-
-        it('shouldn\'t delete and init buffer if gl context not changed', () => {
-            const spy = sinon.spy(gl, 'createBuffer');
-            buffer.bind(gl, 1);
-            buffer.bind(gl, 1);
-
-            assert.ok(spy.calledOnce);
-        });
-
         it('should init buffer with float type', () => {
             const spy = sinon.spy(gl, 'vertexAttribPointer');
             buffer.bind(gl, 1);
@@ -93,7 +60,9 @@ describe('Buffer', () => {
         });
 
         it('should init buffer with unsigned byte type', () => {
-            buffer.dataType = Buffer.UnsignedByte;
+            const buffer = new Buffer(new Float32Array(), {
+                dataType: Buffer.UnsignedByte
+            });
             const spy = sinon.spy(gl, 'vertexAttribPointer');
             buffer.bind(gl, 1);
             const args = spy.args[0];
@@ -105,14 +74,6 @@ describe('Buffer', () => {
             buffer.bind(gl, 1);
             const args = spy.args[0];
             assert.equal(args[3], false);
-        });
-
-        it('should init with normalized = true', () => {
-            buffer.normalized = true;
-            const spy = sinon.spy(gl, 'vertexAttribPointer');
-            buffer.bind(gl, 1);
-            const args = spy.args[0];
-            assert.equal(args[3], true);
         });
 
         it('should call vertexAttribPointer with arguments from options', () => {
@@ -132,36 +93,6 @@ describe('Buffer', () => {
             assert.equal(args[3], options.normalized);
             assert.equal(args[4], options.stride);
             assert.equal(args[5], options.offset);
-        });
-    });
-
-    describe('#getArray', () => {
-        it('should return same squareVertices', () => {
-            assert.deepEqual(squareVertices, slice(buffer.getArray()));
-        });
-    });
-
-    describe('#getElement', () => {
-        it('should return second element', () => {
-            const element = squareVertices.slice(3, 6);
-            assert.deepEqual(element, slice(buffer.getElement(1)));
-        });
-    });
-
-    describe('#getTriangle', () => {
-        it('should return second triangle', () => {
-            const triangle = squareVertices.slice(9, 18);
-            assert.deepEqual(triangle, flatten(buffer.getTriangle(1)));
-        });
-    });
-
-    describe('#concat', () => {
-        it('should concat buffer', () => {
-            const anotherVertexBuffer = new Buffer([9, 9, 9], 3);
-
-            buffer.concat(anotherVertexBuffer);
-
-            assert.equal(buffer.getArray().length, 21);
         });
     });
 

--- a/test/Geometry.spec.js
+++ b/test/Geometry.spec.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import {slice, cubeVertices} from './utils';
 
-import Buffer from '../src/Buffer';
+import GeometryBuffer from '../src/GeometryBuffer';
 import Box from '../src/math/Box';
 
 import Geometry from '../src/Geometry';
@@ -11,7 +11,7 @@ describe('Geometry', () => {
 
     beforeEach(() => {
         geometry = new Geometry();
-        buffer = new Buffer(new Float32Array(cubeVertices), 3);
+        buffer = new GeometryBuffer(new Float32Array(cubeVertices));
     });
 
     describe('#constructor', () => {
@@ -42,7 +42,7 @@ describe('Geometry', () => {
                 0, 0, 1
             ];
 
-            const buffer = new Buffer(new Float32Array(triangle), 3);
+            const buffer = new GeometryBuffer(new Float32Array(triangle));
 
             geometry.setBuffer('position', buffer);
             geometry.computeNormals();
@@ -99,7 +99,7 @@ describe('Geometry', () => {
                 0, -1, 0,
                 0, 0, 1
             ];
-            const anotherBuffer = new Buffer(new Float32Array(triangleVertices), 3);
+            const anotherBuffer = new GeometryBuffer(new Float32Array(triangleVertices));
             anotherGeometry.setBuffer('position', anotherBuffer);
 
             geometry.concat(anotherGeometry);

--- a/test/GeometryBuffer.js
+++ b/test/GeometryBuffer.js
@@ -1,0 +1,55 @@
+import assert from 'assert';
+import {slice, flatten} from './utils';
+
+import GeometryBuffer from '../src/GeometryBuffer';
+
+describe('GeometryBuffer', () => {
+    let squareVertices, buffer;
+
+    beforeEach(() => {
+        squareVertices = [
+            -1, 0, -1,
+            1, 0, -1,
+            -1, 0, 1,
+            1, 0, 1,
+            -1, 0, 1,
+            1, 0, -1
+        ];
+
+        buffer = new GeometryBuffer(new Float32Array(squareVertices));
+    });
+
+    afterEach(() => {
+        squareVertices = buffer = null;
+    });
+
+    describe('#getArray', () => {
+        it('should return same squareVertices', () => {
+            assert.deepEqual(squareVertices, slice(buffer.getArray()));
+        });
+    });
+
+    describe('#getElement', () => {
+        it('should return second element', () => {
+            const element = squareVertices.slice(3, 6);
+            assert.deepEqual(element, slice(buffer.getElement(1)));
+        });
+    });
+
+    describe('#getTriangle', () => {
+        it('should return second triangle', () => {
+            const triangle = squareVertices.slice(9, 18);
+            assert.deepEqual(triangle, flatten(buffer.getTriangle(1)));
+        });
+    });
+
+    describe('#concat', () => {
+        it('should concat buffer', () => {
+            const anotherVertexBuffer = new GeometryBuffer([9, 9, 9]);
+
+            buffer.concat(anotherVertexBuffer);
+
+            assert.equal(buffer.getArray().length, 21);
+        });
+    });
+});

--- a/test/Raycaster.spec.js
+++ b/test/Raycaster.spec.js
@@ -6,7 +6,7 @@ import {vec3} from 'gl-matrix';
 import Ray from '../src/math/Ray';
 import Object3D from '../src/Object3D';
 import Geometry from '../src/Geometry';
-import Buffer from '../src/Buffer';
+import GeometryBuffer from '../src/GeometryBuffer';
 import BasicMeshMaterial from '../src/materials/BasicMeshMaterial';
 import Mesh from '../src/Mesh';
 
@@ -52,7 +52,7 @@ describe('Raycaster', () => {
         it('should call intersectMesh with mesh', () => {
             const material = new BasicMeshMaterial();
             const geometry = new Geometry();
-            geometry.setBuffer('position', new Buffer(new Float32Array(cubeVertices), 3));
+            geometry.setBuffer('position', new GeometryBuffer(new Float32Array(cubeVertices), 3));
             const mesh = new Mesh(geometry, material);
 
             const spy = sinon.spy(raycaster, 'intersectMesh');
@@ -116,7 +116,7 @@ describe('Raycaster', () => {
         beforeEach(() => {
             const material = new BasicMeshMaterial();
             const geometry = new Geometry();
-            geometry.setBuffer('position', new Buffer(new Float32Array(cubeVertices), 3));
+            geometry.setBuffer('position', new GeometryBuffer(new Float32Array(cubeVertices), 3));
 
             mesh = new Mesh(geometry, material);
         });


### PR DESCRIPTION
Выделил часть кода из `Buffer` отвечающего за работу с геометрией в отдельный класс `GeometryBuffer`(название обсуждаемо).

Эта часть кода уже давно была не совсем на месте, т.к. `Buffer` мог принимать не только типизированные массивы, но и `ArrayBuffer`, а в этом случае все методы для работы с геометрией не работали.

Теперь обычный `Buffer` удаляет ссылку на данные, переданные ему при инициализации, тем самым позволяя освободить память.

Немного поменял интерфейс создания `Buffer`, теперь вторым параметром передаются параметры для связывания буферы с видеокартой, аналогично как это сделано в `BufferChannel`.

Удалил проверки на `preparedGlContext`, пользователям библиотеки самим стоит следить за сменой контекста, и самим инициализировать буферы заново (скорее всего затронет демку в Этажах).