### PR TITLE
Remove shader get log methods

### DIFF
--- a/src/Shader.js
+++ b/src/Shader.js
@@ -62,10 +62,6 @@ class Shader {
         const shader = this._shader = gl.createShader(glType);
         gl.shaderSource(shader, this._code);
         gl.compileShader(shader);
-
-        if (process.env.NODE_ENV !== 'production' && !gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            console.log(gl.getShaderInfoLog(shader));
-        }
     }
 }
 

--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -98,12 +98,6 @@ class ShaderProgram {
 
         gl.linkProgram(this._webglProgram);
 
-        if (process.env.NODE_ENV !== 'production' && !gl.getProgramParameter(this._webglProgram, gl.LINK_STATUS)) {
-            console.error(gl.getProgramInfoLog(this._webglProgram));
-            this._status = ShaderProgram.FAILED;
-            return;
-        }
-
         this._status = ShaderProgram.READY;
 
         for (const name in this.attributes) {


### PR DESCRIPTION
Код обернутый в `if (process.env.NODE_ENV !== 'production')` все равно просачивается на бой, поскольку многие бандлеры не парсят файлы из `node_modules`.

Поэтому убрал эти проверки полностью, т.к. они тормозят и вызывают остановку конвейера gpu.

Теперь если сломались шейдеры, будут подать стандартные варнинги в консоль от браузера, а если нужно узнать подробнее об ошибке, то можно воспользоваться вот таким хаком https://gist.github.com/Trufi/308a602609b6d2e36b50c733f2f6801e