### PR TITLE
При ошибке компиляции шейдера больше не делается попытки его скомпилировать

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2gl",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "description": "WebGL library for 2GIS projects",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2gl",
-  "version": "0.8.1-0",
+  "version": "0.8.1-shader-errors.0",
   "description": "WebGL library for 2GIS projects",
   "repository": {
     "type": "git",

--- a/src/Shader.js
+++ b/src/Shader.js
@@ -62,6 +62,9 @@ class Shader {
         const shader = this._shader = gl.createShader(glType);
         gl.shaderSource(shader, this._code);
         gl.compileShader(shader);
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+            throw new Error('Shader compile error');
+        }
     }
 }
 

--- a/src/Shader.js
+++ b/src/Shader.js
@@ -63,7 +63,7 @@ class Shader {
         gl.shaderSource(shader, this._code);
         gl.compileShader(shader);
         if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            throw new Error('Shader compile error');
+            throw new Error(gl.getShaderInfoLog(shader));
         }
     }
 }

--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -125,7 +125,7 @@ class ShaderProgram {
     
             gl.linkProgram(this._webglProgram);
             if (!gl.getProgramParameter(this._webglProgram, gl.LINK_STATUS)) {
-                console.error('Shader program link error');
+                throw new Error(gl.getProgramInfoLog(this._webglProgram));
             }
     
             this._linked = true;    

--- a/src/ShaderProgram.js
+++ b/src/ShaderProgram.js
@@ -31,6 +31,7 @@ class ShaderProgram {
 
         this._linked = false;
         this._located = false;
+        this._error = false;
     }
 
     /**
@@ -39,8 +40,14 @@ class ShaderProgram {
      * @param {WebGLRenderingContext} gl
      */
     enable(gl) {
+        if (this._error) {
+            return this;
+        }
         this.link(gl);
         this.locate(gl);
+        if (this._error) {
+            return this;
+        }
 
         gl.useProgram(this._webglProgram);
 
@@ -55,6 +62,9 @@ class ShaderProgram {
      * @param {Object} [attributes] Key-value объект содержащий значения атрибутов
      */
     bind(gl, uniforms, attributes) {
+        if (this._error) {
+            return this;
+        }
         if (uniforms) {
             for (const name in uniforms) {
                 this.uniforms[name].bind(gl, uniforms[name]);
@@ -76,6 +86,10 @@ class ShaderProgram {
      * @param {WebGLRenderingContext} gl
      */
     disable(gl) {
+        if (this._error) {
+            return this;
+        }
+
         for (const name in this.attributes) {
             this.attributes[name].disable(gl);
         }
@@ -90,27 +104,35 @@ class ShaderProgram {
      * @param {WebGLRenderingContext} gl
      */
     link(gl) {
-        if (this._linked) {
+        if (this._linked || this._error) {
             return this;
         }
 
-        this._webglProgram = gl.createProgram();
+        try {
+            this._webglProgram = gl.createProgram();
 
-        if (this._vertexShader) {
-            gl.attachShader(this._webglProgram, this._vertexShader.get(gl));
+            if (this._vertexShader) {
+                gl.attachShader(this._webglProgram, this._vertexShader.get(gl));
+            }
+    
+            if (this._fragmentShader) {
+                gl.attachShader(this._webglProgram, this._fragmentShader.get(gl));
+            }
+    
+            for (const name in this.attributes) {
+                this.attributes[name].bindLocation(gl, this._webglProgram);
+            }
+    
+            gl.linkProgram(this._webglProgram);
+            if (!gl.getProgramParameter(this._webglProgram, gl.LINK_STATUS)) {
+                console.error('Shader program link error');
+            }
+    
+            this._linked = true;    
+        } catch (error) {
+            this._error = true;
+            throw error;
         }
-
-        if (this._fragmentShader) {
-            gl.attachShader(this._webglProgram, this._fragmentShader.get(gl));
-        }
-
-        for (const name in this.attributes) {
-            this.attributes[name].bindLocation(gl, this._webglProgram);
-        }
-
-        gl.linkProgram(this._webglProgram);
-
-        this._linked = true;
 
         return this;
     }
@@ -122,7 +144,7 @@ class ShaderProgram {
      * @param {WebGLRenderingContext} gl
      */
     locate(gl) {
-        if (this._located) {
+        if (this._located || this._error) {
             return this;
         }
 


### PR DESCRIPTION
Чтобы проверить это изменение нужно намеренно допустить ошибку в каком-нибудь шейдере. Я делал так (в road.vsh)

```diff
--- a/road.vsh
+++ b/road.vsh
@@ -22,7 +22,7 @@ void main()
     float half_width = 0.5 * (u_float_width + 1.0);
 
-    vec4 normals = a_vec4_normals * normal_unpack_multiplier * half_width;
+    vec4 normals = a_vec4_normals * normal_unpack_multiplier * half_width - blah;
     vec2 extender = normals.xy;
     vec2 normal = normals.zw;
```

или так

```diff
--- a/road.vsh
+++ b/road.vsh
@@ -22,7 +22,7 @@ void main()
     float half_width = 0.5 * (u_float_width + 1.0);
 
-    vec4 normals = a_vec4_normals * normal_unpack_multiplier * half_width;
+    vec4 normals = a_vec4_normals * normal_unpack_multiplier * half_width - - - -;
     vec2 extender = normals.xy;
     vec2 normal = normals.zw;
```

Сообщение об ошибке появляется только один раз.