### PR TITLE
add texture type option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,7 @@ declare module '2gl' {
         premultiplyAlpha: boolean;
         size?: Vec2;
         unit: number | undefined;
+        type?: number;
     }
 
     export class Texture {
@@ -115,6 +116,8 @@ declare module '2gl' {
         static RgbaFormat: number;
         static AlphaFormat: number;
         static RgbFormat: number;
+        static UnsignedByte: number;
+        static Float: number
         static defaultOptions: TextureOptions;
 
         public readonly options: TextureOptions;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2gl",
-  "version": "0.9.1",
+  "version": "0.10.1",
   "description": "WebGL library for 2GIS projects",
   "repository": {
     "type": "git",

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -237,5 +237,5 @@ export default Texture;
  * @property {Boolean} premultiplyAlpha
  * @property {?Number[]} size
  * @property {?Number} unit
- * @property {?Number} type
+ * @property {?TextureType} type
  */

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -90,7 +90,7 @@ class Texture {
             0,
             x, y,
             this._toGlParam(gl, this.options.format),
-            gl.UNSIGNED_BYTE,
+            this._toGlParam(gl, this.options.type),
             src,
         );
 
@@ -118,7 +118,7 @@ class Texture {
                 this.options.size[1],
                 0,
                 this._toGlParam(gl, this.options.format),
-                gl.UNSIGNED_BYTE,
+                this._toGlParam(gl, this.options.type),
                 this._src
             );
         } else {
@@ -127,7 +127,7 @@ class Texture {
                 0,
                 this._toGlParam(gl, this.options.format),
                 this._toGlParam(gl, this.options.format),
-                gl.UNSIGNED_BYTE,
+                this._toGlParam(gl, this.options.type),
                 this._src
             );
         }
@@ -165,6 +165,10 @@ class Texture {
         if (param === Texture.RgbaFormat) { return gl.RGBA; }
         if (param === Texture.AlphaFormat) { return gl.ALPHA; }
         if (param === Texture.RgbFormat) { return gl.RGB; }
+
+        if (param === Texture.UnsignedByte) { return gl.UNSIGNED_BYTE; }
+        if (param === Texture.Float) { return gl.FLOAT; }
+
         return null;
     }
 }
@@ -184,6 +188,9 @@ Texture.RgbaFormat = 11;
 Texture.AlphaFormat = 12;
 Texture.RgbFormat = 13;
 
+Texture.UnsignedByte = 14;
+Texture.Float = 15;
+
 Texture.defaultOptions = {
     magFilter: Texture.LinearFilter,
     minFilter: Texture.LinearMipMapLinearFilter,
@@ -193,6 +200,7 @@ Texture.defaultOptions = {
     generateMipmaps: true,
     flipY: true,
     premultiplyAlpha: true,
+    type: Texture.UnsignedByte,
 };
 
 export default Texture;
@@ -212,6 +220,10 @@ export default Texture;
  */
 
 /**
+ * @typedef {Texture.UnsignedByte | Texture.Float} TextureType
+ */
+
+/**
  * Параметры связывания текстуры
  *
  * @typedef {Object} TextureOptions
@@ -225,4 +237,5 @@ export default Texture;
  * @property {Boolean} premultiplyAlpha
  * @property {?Number[]} size
  * @property {?Number} unit
+ * @property {?Number} type
  */

--- a/test/MultiSprite.spec.js
+++ b/test/MultiSprite.spec.js
@@ -136,9 +136,9 @@ describe('MultiSprite', () => {
             it('should update buffer', () => {
                 multiSprite.setOpacity(0, 0.5);
 
-                assert.deepEqual(multiSprite._data.colorAlpha.array, [
+                assert.deepEqual(multiSprite._data.colorAlpha.array, new Float32Array([
                     0.5, 0.5, 0.5, 0.5, 0.5, 0.5
-                ]);
+                ]));
             });
         });
 
@@ -146,14 +146,14 @@ describe('MultiSprite', () => {
             it('should update buffer', () => {
                 multiSprite.setPosition(0, [5, 7]);
 
-                assert.deepEqual(multiSprite._data.position.array, [
+                assert.deepEqual(multiSprite._data.position.array, new Float32Array([
                     5, 7, 0,
                     5, 7, 0,
                     5, 7, 0,
                     5, 7, 0,
                     5, 7, 0,
                     5, 7, 0
-                ]);
+                ]));
             });
         });
 
@@ -161,14 +161,14 @@ describe('MultiSprite', () => {
             it('should update buffer', () => {
                 multiSprite.setElevation(0, 5);
 
-                assert.deepEqual(multiSprite._data.position.array, [
+                assert.deepEqual(multiSprite._data.position.array, new Float32Array([
                     1, 2, 5,
                     1, 2, 5,
                     1, 2, 5,
                     1, 2, 5,
                     1, 2, 5,
                     1, 2, 5
-                ]);
+                ]));
             });
         });
 
@@ -176,14 +176,14 @@ describe('MultiSprite', () => {
             it('should update buffer', () => {
                 multiSprite.setSize(0, [5, 7]);
 
-                assert.deepEqual(multiSprite._data.scale.array, [
+                assert.deepEqual(multiSprite._data.scale.array, new Float32Array([
                     5, 7,
                     5, 7,
                     5, 7,
                     5, 7,
                     5, 7,
                     5, 7
-                ]);
+                ]));
             });
         });
 
@@ -191,14 +191,14 @@ describe('MultiSprite', () => {
             it('should update buffer', () => {
                 multiSprite.setOffset(0, [5, 7]);
 
-                assert.deepEqual(multiSprite._data.offset.array, [
+                assert.deepEqual(multiSprite._data.offset.array, new Float32Array([
                     5, 7,
                     5, 7,
                     5, 7,
                     5, 7,
                     5, 7,
                     5, 7
-                ]);
+                ]));
             });
         });
 
@@ -206,14 +206,14 @@ describe('MultiSprite', () => {
             it('should update buffer', () => {
                 multiSprite.setUV(0, [1, 2, 3, 4]);
 
-                assert.deepEqual(multiSprite._data.texture.array, [
+                assert.deepEqual(multiSprite._data.texture.array, new Float32Array([
                     3, -3,
                     3, -1,
                     1, -3,
                     1, -1,
                     1, -3,
                     3, -1
-                ]);
+                ]));
             });
         });
     });

--- a/test/math/Plane.spec.js
+++ b/test/math/Plane.spec.js
@@ -55,7 +55,7 @@ describe('Plane', () => {
         let newNormal, newConstant;
 
         before(() => {
-            newNormal = [0, 1, 2];
+            newNormal = new Float64Array([0, 1, 2]);
             newConstant = 15;
         });
 
@@ -93,9 +93,9 @@ describe('Plane', () => {
         });
 
         it('should change normal right', () => {
-            assert.deepEqual(plane.normal, [5, 0, 0]);
+            assert.deepEqual(plane.normal, new Float64Array([5, 0, 0]));
             plane.normalize();
-            assert.deepEqual(plane.normal, [1, 0, 0]);
+            assert.deepEqual(plane.normal, new Float64Array([1, 0, 0]));
         });
     });
 });


### PR DESCRIPTION
Добавлена поддержка типа текстуры (числовой формат компонента цвета). Кроме `Texture.UnsignedByte`, добавлен `Texture.Float`, который можно использовать вместе с расширениями `OES_texture_float` и `OES_texture_float_linear`.