### PR TITLE
Проверяем наличие WebGL2RenderingContext в window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2gl",
-  "version": "0.11.1-webgl2-fix.0",
+  "version": "0.11.1",
   "description": "WebGL library for 2GIS projects",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2gl",
-  "version": "0.11.0",
+  "version": "0.11.1-webgl2-fix.0",
   "description": "WebGL library for 2GIS projects",
   "repository": {
     "type": "git",

--- a/src/Vao.js
+++ b/src/Vao.js
@@ -88,7 +88,7 @@ class Vao {
     _glCreateVertexArray() {
         const gl = this._gl;
         const ext = this._ext;
-        if (gl instanceof WebGL2RenderingContext) {
+        if (this._isWebGL2(gl)) {
             return gl.createVertexArray();
         } else if (ext) {
             return ext.createVertexArrayOES();
@@ -98,7 +98,7 @@ class Vao {
     _glBindVertexArray(vao) {
         const gl = this._gl;
         const ext = this._ext;
-        if (gl instanceof WebGL2RenderingContext) {
+        if (this._isWebGL2(gl)) {
             gl.bindVertexArray(vao);
         } else if (ext) {
             ext.bindVertexArrayOES(vao);
@@ -111,11 +111,15 @@ class Vao {
     _glDeleteVertexArray(vao) {
         const gl = this._gl;
         const ext = this._ext;
-        if (gl instanceof WebGL2RenderingContext) {
+        if (this._isWebGL2(gl)) {
             gl.deleteVertexArray(vao);
         } else if (ext) {
             ext.deleteVertexArrayOES(vao);
         }
+    }
+
+    _isWebGL2 (gl) {
+        return 'WebGL2RenderingContext' in window && gl instanceof WebGL2RenderingContext
     }
 }
 

--- a/test/Vao.spec.js
+++ b/test/Vao.spec.js
@@ -11,10 +11,16 @@ describe('Vao', () => {
 
     function mockWebGL2 () {
         global.WebGL2RenderingContext = GlContext;
+        global.window = {
+            WebGL2RenderingContext: global.WebGL2RenderingContext
+        }
     }
 
     function mockWebGL1 () {
         global.WebGL2RenderingContext = function () {}
+        global.window = {
+            WebGL2RenderingContext: global.WebGL2RenderingContext
+        }
     }
 
     afterEach(() => {


### PR DESCRIPTION
Тестирование показало, что недостаточно просто набрать

```
gl instanceof WebGL2RenderingContext
```

Такой код будет валиться на устройствах, где отсутствует класс WebGL2RenderingContext в объекте window. Чтобы этого избежать была сделана дополнительная проверка.